### PR TITLE
Correct set_exptime

### DIFF
--- a/camerad/archon.cpp
+++ b/camerad/archon.cpp
@@ -103,6 +103,56 @@ namespace Archon {
   }
   /**************** Archon::Interface::interface ******************************/
 
+
+  /***** Archon::Interface::set_exptime ***************************************/
+  /**
+   * @brief      set exposure time
+   * @details    This takes a floating point exposure time (sec) and writes it
+   *             to the sec and/or msec parameters on the Archon, as appropriate,
+   *             then updates the camera info class on success.
+   * @param[in]  exptime        exposure time in seconds
+   * @param[in]  sec_param      reference to parameter name to hold sec
+   * @param[in]  msec_param     reference to parameter name to hold msec
+   * @param[in]  info           reference to Camera::Information object
+   * @throws     std::runtime_error
+   * @throws     std::exception
+   *
+   */
+  void Interface::set_exptime(double exptime,
+                              const std::string &sec_param,
+                              const std::string &msec_param,
+                              Camera::Information &info) {
+    const std::string function("Archon::Interface::set_exptime");
+
+    // Archon connection required to set exptime
+    if (!this->archon.isconnected()) {
+      throw std::runtime_error("connection not open to controller");
+    }
+
+    // Exposure time parameters must be defined
+    if (sec_param.empty() || msec_param.empty()) {
+      throw std::runtime_error("expsure time parameters not defined");
+    }
+
+    try {
+      // Split the requested exposure time into seconds and milliseconds
+      auto [sec, msec] = info.exposure_time.split(exptime);
+
+      // Set the sec and msec parameters on the controller,
+      // store the exptime in the class on success.
+      if ( (set_parameter(sec_param, sec)   == NO_ERROR) &&
+           (set_parameter(msec_param, msec) == NO_ERROR) ) {
+        info.exposure_time.set(exptime);
+      }
+      else throw std::runtime_error("could not write exposure time parameters to controller");
+    }
+    catch (const std::exception &e) {
+      throw;
+    }
+  }
+  /***** Archon::Interface::set_exptime ***************************************/
+
+
   /***** Archon::Interface::do_power ******************************************/
   /**
    * @brief      set/get the power state

--- a/camerad/archon.h
+++ b/camerad/archon.h
@@ -104,9 +104,6 @@ namespace Archon {
         Common::FitsKeys userkeys; //!< instantiate a Common object
         Common::FitsKeys systemkeys; //!< instantiate a Common object
 
-        Camera::ExposureTime fcs_exposure_time;  //!< exposure time for FCS detector
-        Camera::ExposureTime sci_exposure_time;  //!< exposure time for SCI detector
-
         Camera::Information fcs_info;   /// this is the main camera_info object
         Camera::Information sci_info;   /// this is the main camera_info object
 
@@ -244,6 +241,11 @@ namespace Archon {
 
         long power( std::string state_in, std::string &retstring );     /// wrapper for do_power
         long do_power( std::string state_in, std::string &retstring );  /// set/get Archon power state
+
+        void set_exptime(double exptime,
+                         const std::string &sec_param,
+                         const std::string &msec_param,
+                         Camera::Information &info);
 
         long expose(std::string nseq_in);
 

--- a/camerad/camera.h
+++ b/camerad/camera.h
@@ -202,7 +202,7 @@ namespace Camera {
             auto [sec,msec] = split(value);
             _sec_part       = sec;
             _msec_part      = msec;
-            _exptime_sec    = value;
+            _exptime_sec    = sec + msec/1000.0;  // store value rounded to nearest msec
           }
           catch (const std::exception &e) { throw; }
         }

--- a/camerad/deimos.cpp
+++ b/camerad/deimos.cpp
@@ -83,7 +83,9 @@ namespace Archon {
     }
 
     // read the exptime from the class
-    retstring = std::to_string(fcs_exposure_time.get());
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(3) << this->fcs_info.exposure_time.get();
+    retstring = oss.str();
 
     return NO_ERROR;
   }
@@ -100,27 +102,11 @@ namespace Archon {
    *
    */
   void Interface::set_fcs_exptime(double exptime) {
-    const std::string function("Archon::Interface::set_fcs_exptime");
-    // Archon connection required to set/get exptime
-    if (!archon.isconnected()) {
-      throw std::runtime_error("connection not open to controller");
-    }
-    // exposure time parameters must be defined
-    if (fcs_exptime_sec_param.empty() || fcs_exptime_msec_param.empty()) {
-      throw std::runtime_error("FCS expsure time parameters not defined");
-    }
     try {
-      // split the requested exposure time into seconds and milliseconds
-      auto [sec, msec] = fcs_exposure_time.split(exptime);
-
-      // set the sec and msec parameters on the controller
-      // and store the exptime in the class on success
-      if ( (set_parameter(fcs_exptime_sec_param, sec)   == NO_ERROR) &&
-           (set_parameter(fcs_exptime_msec_param, msec) == NO_ERROR) ) {
-        fcs_info.exposure_time.set(exptime);
-        fcs_exposure_time.set(exptime);
-      }
-      else throw std::runtime_error("could not set FCS exposure time parameters");
+      this->set_exptime(exptime,
+                        this->fcs_exptime_sec_param,
+                        this->fcs_exptime_msec_param,
+                        this->fcs_info);
     }
     catch (const std::exception &e) {
       throw;
@@ -263,7 +249,9 @@ namespace Archon {
     }
 
     // read the exptime from the class
-    retstring = std::to_string(sci_exposure_time.get());
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(3) << this->sci_info.exposure_time.get();
+    retstring = oss.str();
 
     return NO_ERROR;
   }
@@ -272,7 +260,7 @@ namespace Archon {
 
   /***** Archon::Interface::set_sci_exptime ***********************************/
   /**
-   * @brief      set SCI exposure time  // TODO THIS COULD BE COMBINED WITH set_fcs_exptime <------------
+   * @brief      set SCI exposure time
    * @details    This function is used internally, and is what actually sets
    *             the exposure time.
    * @param[in]  exptime  double-precision exposure time in seconds
@@ -280,27 +268,11 @@ namespace Archon {
    *
    */
   void Interface::set_sci_exptime(double exptime) {
-    const std::string function("Archon::Interface::set_sci_exptime");
-    // Archon connection required to set/get exptime
-    if (!archon.isconnected()) {
-      throw std::runtime_error("connection not open to controller");
-    }
-    // exposure time parameters must be defined
-    if (sci_exptime_sec_param.empty() || sci_exptime_msec_param.empty()) {
-      throw std::runtime_error("SCI expsure time parameters not defined");
-    }
     try {
-      // split the requested exposure time into seconds and milliseconds
-      auto [sec, msec] = sci_exposure_time.split(exptime);
-
-      // set the sec and msec parameters on the controller
-      // and store the exptime in the class on success
-      if ( (set_parameter(sci_exptime_sec_param, sec)   == NO_ERROR) &&
-           (set_parameter(sci_exptime_msec_param, msec) == NO_ERROR) ) {
-        sci_info.exposure_time.set(exptime);
-        sci_exposure_time.set(exptime);
-      }
-      else throw std::runtime_error("could not set SCI exposure time parameters");
+      this->set_exptime(exptime,
+                        this->sci_exptime_sec_param,
+                        this->sci_exptime_msec_param,
+                        this->sci_info);
     }
     catch (const std::exception &e) {
       throw;


### PR DESCRIPTION
Generalizes `set_exptime()` instead of having separate but identical code for `set_fcs_exptime()` and `set_sci_exptime()`.

This also now correctly returns the exposure time as rounded to nearest msec.