### PR TITLE
Introduces Instrument Modules

### DIFF
--- a/camerad/CMakeLists.txt
+++ b/camerad/CMakeLists.txt
@@ -10,8 +10,11 @@ set( CAMERAD_DIR ${PROJECT_BASE_DIR}/camerad )
 
 set( CMAKE_CXX_STANDARD 17 )
 
-include_directories( ${PROJECT_BASE_DIR}/utils )
-include_directories( ${PROJECT_BASE_DIR}/common )
+include_directories(${CAMERAD_DIR}
+                    ${CAMERAD_DIR}/Instruments
+                    ${PROJECT_BASE_DIR}/utils
+                    ${PROJECT_BASE_DIR}/common
+		    )
 link_directories( ${PROJECT_BASE_DIR}/lib )
 
 # ----------------------------------------------------------------------------
@@ -22,7 +25,7 @@ option(CONTROLLER "Choose controller type { bob joe archon astrocam }")
 # bob
 # ----------------------------------------------------------------------------
 if (CONTROLLER STREQUAL "bob")
-  message (STATUS "building for Bob")
+  message (STATUS "controller: Bob")
   add_definitions(-DCONTROLLER_BOB)
   set (INTERFACE_SOURCES
       ${CAMERAD_DIR}/bob_interface.cpp
@@ -31,7 +34,7 @@ if (CONTROLLER STREQUAL "bob")
 # joe
 # ----------------------------------------------------------------------------
 elseif (CONTROLLER STREQUAL "joe")
-  message (STATUS "building for Joe")
+  message (STATUS "controller: Joe")
   add_definitions(-DCONTROLLER_JOE)
   set (INTERFACE_SOURCES
       ${CAMERAD_DIR}/joe_interface.cpp
@@ -40,7 +43,7 @@ elseif (CONTROLLER STREQUAL "joe")
 # Archon
 # ----------------------------------------------------------------------------
 elseif (CONTROLLER STREQUAL "archon")
-  message (STATUS "building for Archon")
+  message (STATUS "controller: Archon")
   add_definitions(-DCONTROLLER_ARCHON)
   set (INTERFACE_TARGET archon)
   set (INTERFACE_SOURCES
@@ -52,7 +55,7 @@ elseif (CONTROLLER STREQUAL "archon")
 # AstroCam ARC-64/66 PCI/e
 # ----------------------------------------------------------------------------
 elseif (CONTROLLER STREQUAL "astrocam")
-  message (STATUS "building for AstroCam GenIII PCI/PCIe")
+  message (STATUS "controller: AstroCam GenIII PCI/PCIe")
   add_definitions (-DCONTROLLER_ASTROCAM)
   set (INTERFACE_TARGET astrocam)
   set (ARCAPI_DIR "${PROJECT_BASE_DIR}/ARC")
@@ -93,13 +96,36 @@ else()
 endif()
 
 # ----------------------------------------------------------------------------
+# default instrument is none
+# ----------------------------------------------------------------------------
+option(INSTRUMENT "Choose instrument { generic ... }")
+if (INSTRUMENT)
+  message(STATUS "instrument: ${INSTRUMENT}")
+  include(Instruments/${INSTRUMENT}/${INSTRUMENT}.cmake)
+else()
+  message(STATUS "instrument: none")
+  set (INSTRUMENT_SOURCES "")
+  # If no instrument is defined then include the factory for the specified controller
+  if (CONTROLLER STREQUAL "archon")
+    set (INSTRUMENT_SOURCES ${CAMERAD_DIR}/archon_interface_factory.cpp)
+  elseif (CONTROLLER STREQUAL "astrocam")
+    set (INSTRUMENT_SOURCES ${CAMERAD_DIR}/astrocam_interface_factory.cpp)
+  elseif (CONTROLLER STREQUAL "bob")
+    set (INSTRUMENT_SOURCES ${CAMERAD_DIR}/bob_interface_factory.cpp)
+  elseif (CONTROLLER STREQUAL "joe")
+    set (INSTRUMENT_SOURCES ${CAMERAD_DIR}/joe_interface_factory.cpp)
+  endif()
+endif()
+
+# ----------------------------------------------------------------------------
 # Camera Interface Base
 # ----------------------------------------------------------------------------
 list (APPEND INTERFACE_SOURCES
   ${CAMERAD_DIR}/camera_interface.cpp
   ${CAMERAD_DIR}/image_process.cpp
+  ${INSTRUMENT_SOURCES}
   )
-add_library(${INTERFACE_TARGET} ${INTERFACE_SOURCES})
+add_library(${INTERFACE_TARGET} ${INTERFACE_SOURCES} ${INSTRUMENT_SOURCES})
 target_link_libraries(${INTERFACE_TARGET}
                       common
                       )

--- a/camerad/CMakeLists.txt
+++ b/camerad/CMakeLists.txt
@@ -125,7 +125,7 @@ list (APPEND INTERFACE_SOURCES
   ${CAMERAD_DIR}/image_process.cpp
   ${INSTRUMENT_SOURCES}
   )
-add_library(${INTERFACE_TARGET} ${INTERFACE_SOURCES} ${INSTRUMENT_SOURCES})
+add_library(${INTERFACE_TARGET} ${INTERFACE_SOURCES})
 target_link_libraries(${INTERFACE_TARGET}
                       common
                       )

--- a/camerad/Instruments/hispec/hispec.cmake
+++ b/camerad/Instruments/hispec/hispec.cmake
@@ -1,0 +1,10 @@
+# ----------------------------------------------------------------------------
+# @file    Instruments/hispec/hispec.cmake
+# @brief   HISPEC-specific input to the CMake build system for camerad
+# @author  David Hale <dhale@caltech.edu>
+# ----------------------------------------------------------------------------
+
+set (INSTRUMENT_SOURCES
+    ${CAMERAD_DIR}/Instruments/hispec/hispec_instrument.cpp
+    ${CAMERAD_DIR}/Instruments/hispec/hispec_interface_factory.cpp
+    )

--- a/camerad/Instruments/hispec/hispec_instrument.cpp
+++ b/camerad/Instruments/hispec/hispec_instrument.cpp
@@ -1,0 +1,53 @@
+/**
+ * @file    Instruments/hispec/hispec_instrument.cpp
+ * @brief   implementation for HISPEC-specific properties
+ * @author  David Hale <dhale@astro.caltech.edu>
+ *
+ */
+
+#include "hispec_instrument.h"
+
+namespace Camera {
+
+  /***** Camera::Hispec::instrument_cmd ***************************************/
+  /**
+   * @brief      dispatcher for HISPEC-specific instrument commands
+   * @details    This allows dispatching instrument specific commands by receiving
+   *             the command and args and calling the appropriate instrument
+   *             specific function.
+   * @param[in]  cmd        command
+   * @param[in]  args       any number of arguments
+   * @param[out] retstring  return string
+   * @return     ERROR|NO_ERROR|HELP
+   *
+   */
+  long Hispec::instrument_cmd(const std::string &cmd,
+                              const std::string &args,
+			      std::string &retstring) {
+    if ( cmd == "hispec_expose" ) {
+      return this->hispec_expose(args, retstring);
+    }
+    else {
+      retstring = "unrecognized command";
+      return ERROR;
+    }
+  }
+  /***** Camera::Hispec::instrument_cmd ***************************************/
+
+
+  /***** Camera::Hispec::hispec_expose ****************************************/
+  /**
+   * @brief      placeholder for example HISPEC-only function
+   * @param[in]  args       any number of arguments
+   * @param[out] retstring  return string
+   * @return     ERROR|NO_ERROR|HELP
+   *
+   */
+  long Hispec::hispec_expose(const std::string &args, std::string &retstring) {
+    const std::string function("Camera::Hispec::hispec_expose");
+    logwrite(function, "hello, world: "+args);
+    retstring="OK";
+    return NO_ERROR;
+  }
+  /***** Camera::Hispec::hispec_expose ****************************************/
+}

--- a/camerad/Instruments/hispec/hispec_instrument.cpp
+++ b/camerad/Instruments/hispec/hispec_instrument.cpp
@@ -35,6 +35,19 @@ namespace Camera {
   /***** Camera::Hispec::instrument_cmd ***************************************/
 
 
+  /***** Camera::Hispec::configure_instrument *********************************/
+  /**
+   * @brief      extract+apply instrument-specific parameters from config file
+   * @throws     std::runtime_error
+   *
+   */
+  void Hispec::configure_instrument() {
+    const std::string function("Camera::Hispec::configure_instrument");
+    logwrite(function, "");
+  }
+  /***** Camera::Hispec::configure_instrument *********************************/
+
+
   /***** Camera::Hispec::hispec_expose ****************************************/
   /**
    * @brief      placeholder for example HISPEC-only function

--- a/camerad/Instruments/hispec/hispec_instrument.h
+++ b/camerad/Instruments/hispec/hispec_instrument.h
@@ -1,0 +1,31 @@
+/**
+ * @file    Instruments/hispec/hispec_instrument.h
+ * @brief   contains properties unique to the HISPEC instrument
+ * @author  David Hale <dhale@astro.caltech.edu>
+ *
+ */
+#pragma once
+
+#include "archon_interface.h"  /// HISPEC uses ArchonInteface
+
+namespace Camera {
+
+  /***** Camera::Hispec *******************************************************/
+  /**
+   * @class    Hispec
+   * @brief    derived class inherits from ArchonInterface
+   * @details  This class describes HISPEC-specific functionality.
+   *
+   */
+  class Hispec : public ArchonInterface {
+    public:
+      // instrument command dispatcher
+      long instrument_cmd(const std::string &cmd,
+                          const std::string &args,
+                          std::string &retstring) override;
+    private:
+      // these are HISPEC-specific functions
+      long hispec_expose(const std::string &args, std::string &retstring);
+  };
+  /***** Camera::Hispec *******************************************************/
+}

--- a/camerad/Instruments/hispec/hispec_instrument.h
+++ b/camerad/Instruments/hispec/hispec_instrument.h
@@ -23,6 +23,9 @@ namespace Camera {
       long instrument_cmd(const std::string &cmd,
                           const std::string &args,
                           std::string &retstring) override;
+
+      void configure_instrument() override;
+
     private:
       // these are HISPEC-specific functions
       long hispec_expose(const std::string &args, std::string &retstring);

--- a/camerad/Instruments/hispec/hispec_interface_factory.cpp
+++ b/camerad/Instruments/hispec/hispec_interface_factory.cpp
@@ -1,0 +1,23 @@
+/**
+ * @file    Instruments/hispec/hispec_interface_factory.cpp
+ * @brief   HISPEC Interface Factory
+ * @author  David Hale <dhale@astro.caltech.edu>
+ *
+ */
+#include "hispec_instrument.h"
+#include "camera_interface.h"
+
+namespace Camera {
+
+  /***** Camera::Interface::create ********************************************/
+  /**
+   * @brief      factory function to create pointer to HISPEC
+   * @return     unique_ptr<Hispec>
+   *
+   */
+  std::unique_ptr<Interface> Interface::create() {
+    return std::make_unique<Hispec>();
+  }
+  /***** Camera::Interface::create ********************************************/
+
+}

--- a/camerad/archon_controller.cpp
+++ b/camerad/archon_controller.cpp
@@ -168,25 +168,26 @@ namespace Camera {
       }
       else continue;
 
+      // validate module number
+      //
+      if (module<1 || module>NMODS) {
+        message.str(""); message << "module " << module << " outside range {1:" << NMODS << "}";
+        logwrite( function, message.str() );
+        throw std::runtime_error("invalid module number");
+      }
+
       // get the module version
       //
       if (tokens[1] == "VERSION") version = tokens[2]; else version = "";
 
       // now store it permanently
       //
-      if ( (module > 0) && (module <= NMODS) ) {
-        try {
-          this->modtype.at(module-1)    = type;      // store the type in a vector indexed by module
-          this->modversion.at(module-1) = version;   // store the type in a vector indexed by module
-        }
-        catch (const std::exception &e) {
-          message.str(""); message << "requested module " << module << " out of range {1:" << NMODS << "}";
-          logwrite( function, message.str() );
-          throw std::runtime_error("invalid module number");
-        }
+      try {
+        this->modtype.at(module-1)    = type;      // store the type in a vector indexed by module
+        this->modversion.at(module-1) = version;   // store the type in a vector indexed by module
       }
-      else {                                          // else should never happen
-        message.str(""); message << "module " << module << " outside range {1:" << NMODS << "}";
+      catch (const std::exception &e) {
+        message.str(""); message << "requested module " << module << " out of range {1:" << NMODS << "}";
         logwrite( function, message.str() );
         throw std::runtime_error("invalid module number");
       }

--- a/camerad/archon_controller.cpp
+++ b/camerad/archon_controller.cpp
@@ -216,6 +216,89 @@ namespace Camera {
   /***** Camera::ArchonController::connect ************************************/
 
 
+  /***** Camera::ArchonController::get_bias_config ****************************/
+  /**
+   * @brief      create the bias configuration key and validate mod and chan
+   * @details    This creates the configuration line needed as a key for both
+   *             reading and writing a bias from and to the Archon configuration.
+   * @return     bias_config_t structure
+   * @throws     std::runtime_error
+   *
+   */
+  ArchonController::bias_config_t ArchonController::get_bias_config(int mod, int chan) const {
+    std::ostringstream oss;
+
+    // Check that the module number is valid
+    if ( (mod < 0) || (mod > NMODS) ) {
+      oss << "module " << mod << ": outside range {0:" << NMODS << "}";
+      throw std::runtime_error(oss.str());
+    }
+
+    // Check that the channel number is valid
+    if ( (chan < 1) || (chan > 30) ) {
+      oss << "bias channel " << mod << ": outside range {1:30}";
+      throw std::runtime_error(oss.str());
+    }
+
+    bias_config_t info;
+    std::ostringstream biasconfig;
+
+    // Use the module type to get LV or HV Bias
+    // and start building the bias configuration string.
+    float vmin, vmax;
+    switch ( this->modtype[ mod-1 ] ) {
+      case MODTYPE_NONE:
+        oss << "module " << mod << " not installed";
+        throw std::runtime_error(oss.str());
+      case MODTYPE_LVBIAS:
+      case MODTYPE_LVXBIAS:
+        biasconfig << "MOD" << mod << "/LV";
+        info.vmin = -14.0;
+        info.vmax = +14.0;
+        break;
+      case MODTYPE_HVBIAS:
+      case MODTYPE_HVXBIAS:
+        biasconfig << "MOD" << mod << "/HV";
+        info.vmin =   0.0;
+        info.vmax = +31.0;
+        break;
+      default:
+        oss << "module " << mod << " not a bias board";
+        throw std::runtime_error(oss.str());
+    }
+
+    // append the channel to the bias configuration string
+    if (chan < 25) {
+      biasconfig << "LC_V" << chan;
+    }
+    else {
+      biasconfig << "HC_V" << (chan-24);
+    }
+
+    info.key = biasconfig.str();
+    return info;
+  }
+  /***** Camera::ArchonController::get_bias_config ****************************/
+
+
+  /***** Camera::ArchonController::make_applymod_command **********************/
+  /**
+   * @brief      creates an APPLYMODx string
+   * @returns    std::string
+   *
+   */
+  std::string ArchonController::make_applymod_command(int mod) const {
+    std::ostringstream oss;
+    oss << "APPLYMOD"
+        << std::setfill('0')
+        << std::setw(2)
+        << std::hex
+        << (mod-1);
+    return oss.str();
+  }
+  /***** Camera::ArchonController::make_applymod_command **********************/
+
+
   /***** Camera::ArchonController::bias ***************************************/
   /**
    * @brief      parse the configuration file for controller-related parameters
@@ -233,92 +316,43 @@ namespace Camera {
       throw std::runtime_error("connection not open to controller");
     }
 
-    // Check that the module number is valid
-    if ( (mod < 0) || (mod > NMODS) ) {
-      oss << "module " << mod << ": outside range {0:" << NMODS << "}";
-      throw std::runtime_error(oss.str());
-    }
+    // creating the bias configuration key also validates mod and chan
+    auto info = get_bias_config(mod, chan);
 
-    // Use the module type to get LV or HV Bias
-    // and start building the bias configuration string.
-    float vmin, vmax;
-    switch ( this->modtype[ mod-1 ] ) {
-      case MODTYPE_NONE:
-        oss << "module " << mod << " not installed";
-        throw std::runtime_error(oss.str());
-      case MODTYPE_LVBIAS:
-      case MODTYPE_LVXBIAS:
-        biasconfig << "MOD" << mod << "/LV";
-        vmin = -14.0;
-        vmax = +14.0;
-        break;
-      case MODTYPE_HVBIAS:
-      case MODTYPE_HVXBIAS:
-        biasconfig << "MOD" << mod << "/HV";
-        vmin =   0.0;
-        vmax = +31.0;
-        break;
-      default:
-        oss << "module " << mod << " not a bias board";
-        throw std::runtime_error(oss.str());
-    }
-
-    // Check that the channel number is valid
-    // and add it to the bias configuration string.
-    if ( (chan < 1) || (chan > 30) ) {
-      oss << "bias channel " << mod << ": outside range {1:30}";
-      throw std::runtime_error(oss.str());
-    }
-    if ( (chan > 0) && (chan < 25) ) {
-      biasconfig << "LC_V" << chan;
-    }
-    if ( (chan > 24) && (chan < 31) ) {
-      biasconfig << "HC_V" << (chan-24);
-    }
-
+    // write the bias configuration line if needed
     if (should_write) {
       bool changed=false;
-      try {
-        // check requested voltage is within range
-        if ( (volts < vmin) || (volts > vmax) ) {
-          oss << volts << " outside range {" << vmin << ":" << vmax << "}";
-          throw std::runtime_error(oss.str());
-        }
-        // write the configuration line to update the bias voltage
-        std::string key = biasconfig.str();
-        std::string val = std::to_string(volts);
-        this->write_config_key(key.c_str(), val.c_str(), changed);
-
-        // send the APPLYMODx command
-        std::ostringstream applyoss;
-        applyoss << "APPLYMOD"
-                 << std::setfill('0')
-                 << std::setw(2)
-                 << std::hex
-                 << (mod-1);
-        long error = this->send_cmd(applyoss.str());
-        if (error != NO_ERROR) {
-          oss << "writing bias configuration " << key << "=" << val;
-          throw std::runtime_error(oss.str());
-        }
-        else if (!changed) {
-          oss << "bias configuration " << key << "=" << val << " unchanged";
-          logwrite(function, oss.str());
-          return;
-        }
-        else {
-          oss << "updated bias configuration " << key << "=" << val;
-          logwrite(function, oss.str());
-          return;
-        }
+      // check requested voltage is within range
+      if ( (volts < info.vmin) || (volts > info.vmax) ) {
+        oss << volts << " outside range {" << info.vmin << ":" << info.vmax << "}";
+        throw std::runtime_error(oss.str());
       }
-      catch (const std::exception &e) {
-        throw;
+
+      // write the configuration line to update the bias voltage
+      std::string val = std::to_string(volts);
+      this->write_config_key(info.key.c_str(), val.c_str(), changed);
+
+      // send the APPLYMODx command
+      long error = this->send_cmd(make_applymod_command(mod));
+
+      if (error != NO_ERROR) {
+        oss << "writing bias configuration " << info.key << "=" << val;
+        throw std::runtime_error(oss.str());
+      }
+      else if (!changed) {
+        oss << "bias configuration " << info.key << "=" << val << " unchanged";
+        logwrite(function, oss.str());
+        return;
+      }
+      else {
+        oss << "updated bias configuration " << info.key << "=" << val;
+        logwrite(function, oss.str());
+        return;
       }
     }
 
     // read the configuration
-    this->get_configmap_value(biasconfig.str(), volts);
+    this->get_configmap_value(info.key, volts);
   }
   /***** Camera::ArchonController::bias ***************************************/
 

--- a/camerad/archon_controller.cpp
+++ b/camerad/archon_controller.cpp
@@ -67,7 +67,8 @@ namespace Camera {
    *
    */
   void ArchonController::configure_controller() {
-    std::stringstream errstr;
+    const std::string function("Camera::ArchonController::configure_controller");
+    logwrite(function, "");
 
     if (this->interface->configfile.n_rows < 1) throw std::runtime_error("empty configuration");
 
@@ -85,9 +86,10 @@ namespace Camera {
           this->archon.setport( std::stoi(this->interface->configfile.arg[row]) );
         }
         catch (const std::exception &e) {
-          errstr << "parsing " << this->interface->configfile.param[row]
-                               << "=" << this->interface->configfile.arg[row] << ": " << e.what();
-          throw std::runtime_error(errstr.str());
+          std::ostringstream oss;
+          oss << "parsing " << this->interface->configfile.param[row]
+                            << "=" << this->interface->configfile.arg[row] << ": " << e.what();
+          throw std::runtime_error(oss.str());
         }
       }
       else

--- a/camerad/archon_controller.cpp
+++ b/camerad/archon_controller.cpp
@@ -76,13 +76,13 @@ namespace Camera {
 
       // ARCHON_IP
       if (this->interface->configfile.param[row]=="ARCHON_IP") {
-        archon.sethost( this->interface->configfile.arg[row] );
+        this->archon.sethost( this->interface->configfile.arg[row] );
       }
       else
       // ARCHON_PORT
       if (this->interface->configfile.param[row]=="ARCHON_PORT") {
         try {
-          archon.setport( std::stoi(this->interface->configfile.arg[row]) );
+          this->archon.setport( std::stoi(this->interface->configfile.arg[row]) );
         }
         catch (const std::exception &e) {
           errstr << "parsing " << this->interface->configfile.param[row]
@@ -100,6 +100,229 @@ namespace Camera {
   /***** Camera::ArchonController::configure_controller ***********************/
 
 
+  /***** Camera::ArchonController::connect ************************************/
+  /**
+   * @brief      parse the configuration file for controller-related parameters
+   * @details    The config file has already been read into the Config class.
+   * @throws     std::runtime_error
+   *
+   */
+  void ArchonController::connect() {
+    const std::string function("Camera::ArchonController::connect");
+
+    // nothing to do if already connected
+    if ( this->archon.isconnected() ) {
+      logwrite(function, "camera connection already open");
+      return;
+    }
+
+    // initialize camera connection
+    try {
+      this->archon.Connect();
+    }
+    catch (const std::exception &e) {
+      throw;
+    }
+
+    std::stringstream message;
+    message << "socket connection to host " << this->archon.gethost()
+            << " port " << this->archon.getport()
+            << " established on fd " << this->archon.getfd();
+    logwrite(function, message.str());
+
+    // get the Archon system information for installed modules
+    std::string reply;
+    if (this->send_cmd(SYSTEM, reply) != NO_ERROR) {   // first the whole reply in one string
+      throw std::runtime_error("getting SYSTEM information");
+    }
+
+    std::vector<std::string> lines, tokens;
+    Tokenize( reply, lines, " " );              // then each line in a separate token "lines"
+
+    for ( const auto &line : lines ) {
+      Tokenize( line, tokens, "_=" );           // finally break each line into tokens to get module, type and version
+      if ( tokens.size() != 3 ) continue;       // need 3 tokens
+
+      std::string version;
+      int module=0;
+      int type=0;
+
+      // get the module number
+      //
+      if ( tokens[0].compare( 0, 9, "BACKPLANE" ) == 0 ) {
+        if ( tokens[1] == "VERSION" ) this->backplaneversion = tokens[2];
+        continue;
+      }
+
+      // get the module and type of each module from MODn_TYPE
+      //
+      if ( (tokens[0].compare( 0, 3, "MOD" ) == 0) && (tokens[1] == "TYPE") ) {
+        try {
+          module = std::stoi(tokens[0].substr(3));
+          type   = std::stoi(tokens[2]);
+        }
+        catch (const std::exception &e) {
+          logwrite(function, "ERROR parsing module/type from \""+line+"\": "+std::string(e.what()));
+          throw std::runtime_error("unexpected SYSTEM information");
+        }
+      }
+      else continue;
+
+      // get the module version
+      //
+      if (tokens[1] == "VERSION") version = tokens[2]; else version = "";
+
+      // now store it permanently
+      //
+      if ( (module > 0) && (module <= NMODS) ) {
+        try {
+          this->modtype.at(module-1)    = type;      // store the type in a vector indexed by module
+          this->modversion.at(module-1) = version;   // store the type in a vector indexed by module
+        }
+        catch (const std::exception &e) {
+          message.str(""); message << "requested module " << module << " out of range {1:" << NMODS << "}";
+          logwrite( function, message.str() );
+          throw std::runtime_error("invalid module number");
+        }
+      }
+      else {                                          // else should never happen
+        message.str(""); message << "module " << module << " outside range {1:" << NMODS << "}";
+        logwrite( function, message.str() );
+        throw std::runtime_error("invalid module number");
+      }
+
+      // Use the module type to resize the gain and offset vectors,
+      // but always use the largest possible value allowed.
+      //
+      int adchans=0;
+      if (type == MODTYPE_ADC) adchans = ( adchans < MAXADCCHANS ? MAXADCCHANS : adchans );
+      if (type == MODTYPE_ADM) adchans = ( adchans < MAXADMCHANS ? MAXADMCHANS : adchans );
+      this->gain.resize( adchans );
+      this->offset.resize( adchans );
+
+      // Check that the AD modules are installed in the correct slot
+      //
+      if ( (type == MODTYPE_ADC || type == MODTYPE_ADM) && (module < 5 || module > 8) ) {
+        message.str(""); message << "AD module (type=" << type << ") cannot be in slot " << module << ". Use slots 5-8";
+        logwrite( function, message.str() );
+        throw std::runtime_error(message.str());
+      }
+    } // end for ( auto line : lines )
+
+    // empty the Archon log
+    //
+    this->fetchlog();
+  }
+  /***** Camera::ArchonController::connect ************************************/
+
+
+  /***** Camera::ArchonController::bias ***************************************/
+  /**
+   * @brief      parse the configuration file for controller-related parameters
+   * @details    The config file has already been read into the Config class.
+   * @throws     std::runtime_error
+   *
+   */
+  void ArchonController::bias(const int &mod, const int &chan, float &volts, const bool &should_write) {
+    const std::string function("Camera::ArchonController::bias");
+    std::ostringstream oss;
+    std::ostringstream biasconfig;
+
+    // nothing to do if no connection open to controller
+    if (!this->archon.isconnected()) {
+      throw std::runtime_error("connection not open to controller");
+    }
+
+    // Check that the module number is valid
+    if ( (mod < 0) || (mod > NMODS) ) {
+      oss << "module " << mod << ": outside range {0:" << NMODS << "}";
+      throw std::runtime_error(oss.str());
+    }
+
+    // Use the module type to get LV or HV Bias
+    // and start building the bias configuration string.
+    float vmin, vmax;
+    switch ( this->modtype[ mod-1 ] ) {
+      case MODTYPE_NONE:
+        oss << "module " << mod << " not installed";
+        throw std::runtime_error(oss.str());
+      case MODTYPE_LVBIAS:
+      case MODTYPE_LVXBIAS:
+        biasconfig << "MOD" << mod << "/LV";
+        vmin = -14.0;
+        vmax = +14.0;
+        break;
+      case MODTYPE_HVBIAS:
+      case MODTYPE_HVXBIAS:
+        biasconfig << "MOD" << mod << "/HV";
+        vmin =   0.0;
+        vmax = +31.0;
+        break;
+      default:
+        oss << "module " << mod << " not a bias board";
+        throw std::runtime_error(oss.str());
+    }
+
+    // Check that the channel number is valid
+    // and add it to the bias configuration string.
+    if ( (chan < 1) || (chan > 30) ) {
+      oss << "bias channel " << mod << ": outside range {1:30}";
+      throw std::runtime_error(oss.str());
+    }
+    if ( (chan > 0) && (chan < 25) ) {
+      biasconfig << "LC_V" << chan;
+    }
+    if ( (chan > 24) && (chan < 31) ) {
+      biasconfig << "HC_V" << (chan-24);
+    }
+
+    if (should_write) {
+      bool changed=false;
+      try {
+        // check requested voltage is within range
+        if ( (volts < vmin) || (volts > vmax) ) {
+          oss << volts << " outside range {" << vmin << ":" << vmax << "}";
+          throw std::runtime_error(oss.str());
+        }
+        // write the configuration line to update the bias voltage
+        std::string key = biasconfig.str();
+        std::string val = std::to_string(volts);
+        this->write_config_key(key.c_str(), val.c_str(), changed);
+
+        // send the APPLYMODx command
+        std::ostringstream applyoss;
+        applyoss << "APPLYMOD"
+                 << std::setfill('0')
+                 << std::setw(2)
+                 << std::hex
+                 << (mod-1);
+        long error = this->send_cmd(applyoss.str());
+        if (error != NO_ERROR) {
+          oss << "writing bias configuration " << key << "=" << val;
+          throw std::runtime_error(oss.str());
+        }
+        else if (!changed) {
+          oss << "bias configuration " << key << "=" << val << " unchanged";
+          logwrite(function, oss.str());
+          return;
+        }
+        else {
+          oss << "updated bias configuration " << key << "=" << val;
+          logwrite(function, oss.str());
+          return;
+        }
+      }
+      catch (const std::exception &e) {
+        throw;
+      }
+    }
+
+    // read the configuration
+    this->get_configmap_value(biasconfig.str(), volts);
+  }
+  /***** Camera::ArchonController::bias ***************************************/
+
+
   /***** Camera::ArchonController::set_exptime ********************************/
   /**
    * @brief      set the exposure time on the controller
@@ -112,7 +335,7 @@ namespace Camera {
    */
   void ArchonController::set_exptime(double exptime) {
     // nothing to do if no connection open to controller
-    if (!archon.isconnected()) {
+    if (!this->archon.isconnected()) {
       throw std::runtime_error("connection not open to controller");
     }
 
@@ -169,7 +392,7 @@ namespace Camera {
     int     error = NO_ERROR;
 
     // nothing to do if no connection open to controller
-    if (!archon.isconnected()) {
+    if (!this->archon.isconnected()) {
       logwrite( function, "ERROR connection not open to controller" );
       return ERROR;
     }
@@ -201,7 +424,7 @@ namespace Camera {
 
     // send the command
     //
-    if ( (archon.Write(scmd)) == -1) {
+    if ( (this->archon.Write(scmd)) == -1) {
       logwrite( function, "ERROR writing to camera socket");
       return ERROR;
     }
@@ -223,13 +446,13 @@ namespace Camera {
     char* buffer = new char[64*1024+1]{};                // temporary buffer for holding Archon replies
     reply.clear();                                       // zero reply buffer
     do {
-      if ( (retval=archon.Poll()) <= 0) {
+      if ( (retval=this->archon.Poll()) <= 0) {
         if (retval==0) { SNPRINTF(message, "Poll timeout waiting for response from Archon command (maybe unrecognized command?)"); error=TIMEOUT; }
         if (retval<0)  { SNPRINTF(message, "Poll error waiting for response from Archon command"); error=ERROR; }
         if ( error != NO_ERROR ) logwrite( function, std::string(message) );
         break;
       }
-      retval = archon.Read(buffer, 64*1024);  // read into temp buffer
+      retval = this->archon.Read(buffer, 64*1024);       // read into temp buffer
       if (retval <= 0) {
         logwrite( function, "ERROR reading Archon" );
         break;
@@ -768,6 +991,32 @@ namespace Camera {
     return error;
   }
   /***** Camera::ArchonController::load_acf ***********************************/
+
+
+  /***** Camera::ArchonController::get_configmap_value ************************/
+  /**
+   * @brief      get the VALUE from configmap for a givenn KEY and assign to a variable
+   * @param[in]  key_in is the KEY
+   * @param[out] value_out reference to variable to contain the VALUE
+   * @throws     std::runtime_error
+   *
+   * This is a template class function so the &value_out reference can be any type.
+   * Throws runtime_error if the key_in KEY is not found, otherwise the VALUE
+   * associated with key_in is assigned to &value_out.
+   *
+   */
+  template <class T>
+  void ArchonController::get_configmap_value(const std::string &key_in, T &value_out) {
+    if ( this->configmap.find(key_in) != this->configmap.end() ) {
+      std::istringstream( this->configmap[key_in].value  ) >> value_out;
+    }
+    else {
+      std::ostringstream oss;
+      oss << "key \"" << key_in << "\" not in configuration";
+      throw std::runtime_error(oss.str());
+    }
+  }
+  /***** Camera::ArchonController::get_configmap_value ************************/
 
 
   /***** Camera::ArchonController::get_status_key *****************************/

--- a/camerad/archon_controller.h
+++ b/camerad/archon_controller.h
@@ -16,6 +16,30 @@
 #include "camera_interface.h"
 #include "camera_information.h"
 
+constexpr int MAXADCCHANS =   16;              //!< max number of ADC channels per controller (4 mod * 4 ch/mod)
+constexpr int MAXADMCHANS =   72;              //!< max number of ADM channels per controller (4 mod * 18 ch/mod)
+
+/**
+ * Archon Module Types
+ */
+constexpr int MODTYPE_NONE    =  0;
+constexpr int MODTYPE_DRIVER  =  1;
+constexpr int MODTYPE_ADC     =  2;
+constexpr int MODTYPE_LVBIAS  =  3;
+constexpr int MODTYPE_HVBIAS  =  4;
+constexpr int MODTYPE_HEATER  =  5;
+constexpr int MODTYPE_HS      =  7;
+constexpr int MODTYPE_HVXBIAS =  8;
+constexpr int MODTYPE_LVXBIAS =  9;
+constexpr int MODTYPE_LVDS    = 10;
+constexpr int MODTYPE_HEATERX = 11;
+constexpr int MODTYPE_XVBIAS  = 12;
+constexpr int MODTYPE_ADF     = 13;
+constexpr int MODTYPE_ADX     = 14;
+constexpr int MODTYPE_ADLN    = 15;
+constexpr int MODTYPE_UNKNOWN = 16;
+constexpr int MODTYPE_ADM     = 17;
+
 struct network_details {
     std::string hostname;
     int port;
@@ -72,9 +96,6 @@ namespace Camera {
 
       void configure_controller() override;
 
-      void   set_exptime(double exptime);
-      double get_exptime() const { return( this->exposure_time->get() ); }
-
       typedef enum {
         FRAME_IMAGE,
         FRAME_RAW,
@@ -118,10 +139,15 @@ namespace Camera {
       std::string sec_param;                //!< Archon parameter for exposure time seconds
       std::string msec_param;               //!< Archon parameter for exposure time milliseconds
 
+      void connect();
+      void bias(const int &mod, const int &chan, float &volts, const bool &should_write);
+      void set_exptime(double exptime);
+      double get_exptime() const { return( this->exposure_time->get() ); }
       long send_cmd(const std::string &cmd, std::string &reply);
       long send_cmd(const std::string &cmd);
       long fetchlog();
       long load_acf(const std::string &filename, bool write_to_archon=true);
+      template <class T> void get_configmap_value(const std::string &key_in, T &value_out);
       long get_status_key(const std::string &key, std::string &value);
       long set_power(int state);
       long get_power();

--- a/camerad/archon_controller.h
+++ b/camerad/archon_controller.h
@@ -159,6 +159,19 @@ namespace Camera {
       long write_config_key(const char* key, int newvalue, bool &changed);
 
       /**
+       * @var     struct bias_config_t
+       * @details structure of bias configuration info
+       */
+      struct bias_config_t {
+	std::string key;
+	float vmin;
+	float vmax;
+      };
+
+      bias_config_t get_bias_config(int mod, int chan) const;
+      std::string make_applymod_command(int mod) const;
+
+      /**
        * @var     struct geometry_t geometry[]
        * @details structure of geometry which is unique to each observing mode
        */

--- a/camerad/archon_interface.cpp
+++ b/camerad/archon_interface.cpp
@@ -106,173 +106,55 @@ namespace Camera {
   /***** Camera::ArchonInterface::bias ****************************************/
   /**
    * @brief      set a bias voltage
-   * @param[in]  args       contains <module> <chan> <voltage>
+   * @param[in]  args       contains <mod> <chan> <volts>
    * @param[out] retstring  
    * @return     ERROR | NO_ERROR | HELP
    *
    */
   long ArchonInterface::bias( const std::string args, std::string &retstring ) {
     const std::string function("Camera::ArchonInterface::bias");
-    std::stringstream message;
-    std::vector<std::string> tokens;
-    std::stringstream biasconfig;
-    int module;
-    int channel;
-    float voltage;
-    float vmin, vmax;
-    bool readonly=true;
+    long error;
 
     // Help
-    //
     if (args=="?" || args=="help") {
       retstring = CAMERAD_BIAS;
-      retstring.append( " <module> <chan> <voltage>\n" );
-      retstring.append( "  set a bias voltage\n" );
+      retstring.append( " <mod> <chan> [ <volts> ]\n" );
+      retstring.append( "  set or optionally get a bias voltage\n" );
       return HELP;
     }
 
-    // must have loaded firmware
-    //
-    if ( ! this->controller->is_firmwareloaded ) {
-      logwrite( function, "ERROR firmware not loaded" );
-      return ERROR;
-    }
-
+    std::vector<std::string> tokens;
     Tokenize(args, tokens, " ");
 
-    if (tokens.size() == 2) {
-      readonly = true;
-
-    } else if (tokens.size() == 3) {
-      readonly = false;
-
-    } else {
-      message.str(""); message << "incorrect number of arguments: " << args << ": expected module channel [voltage]";
-      logwrite( function, message.str() );
-      return ERROR;
-    }
-
     try {
-      module  = std::stoi( tokens[0] );
-      channel = std::stoi( tokens[1] );
-      if (!readonly) voltage = std::stof( tokens[2] );
+      int mod, chan;
+      float volts;
+      size_t ntok = tokens.size();
+      bool should_write=false;
+      if (ntok==3) {
+        volts = std::stof(tokens.at(2));
+        should_write = true;
+      }
+      if (ntok==2 || ntok==3) {
+        mod  = std::stoi(tokens.at(0));
+        chan = std::stoi(tokens.at(1));
+      }
+      if (ntok != 2 && ntok != 3) {
+        throw std::runtime_error("expected <mod> <chan> [ <volts> ]");
+      }
+
+      this->controller->bias(mod, chan, volts, should_write);
+      std::ostringstream oss;
+      oss << std::fixed << std::setprecision(3) << volts;
+      retstring=oss.str();
+      error=NO_ERROR;
     }
     catch (const std::exception &e) {
-      message.str(""); message << "ERROR parsing \"" << args << "\": expected <module> <channel> [ voltage ]: "
-                               << e.what();
-      logwrite( function, message.str() );
-      return ERROR;
-
+      retstring=std::string(e.what());
+      error=ERROR;
     }
 
-    // Check that the module number is valid
-    //
-    if ( (module < 0) || (module > NMODS) ) {
-      message.str(""); message << "module " << module << ": outside range {0:" << NMODS << "}";
-      logwrite( function, message.str() );
-      return ERROR;
-    }
-
-    // Use the module type to get LV or HV Bias
-    // and start building the bias configuration string.
-    //
-    switch ( this->controller->modtype[ module-1 ] ) {
-      case 0:
-        message.str(""); message << "module " << module << " not installed";
-        logwrite( function, message.str() );
-        return ERROR;
-        break;
-      case 3:  // LVBias
-      case 9:  // LVXBias
-        biasconfig << "MOD" << module << "/LV";
-        vmin = -14.0;
-        vmax = +14.0;
-        break;
-      case 4:  // HVBias
-      case 8:  // HVXBias
-        biasconfig << "MOD" << module << "/HV";
-        vmin =   0.0;
-        vmax = +31.0;
-        break;
-      default:
-        message.str(""); message << "module " << module << " not a bias board";
-        logwrite( function, message.str() );
-        return ERROR;
-        break;
-    }
-
-    // Check that the channel number is valid
-    // and add it to the bias configuration string.
-    //
-    if ( (channel < 1) || (channel > 30) ) {
-      message.str(""); message << "bias channel " << module << ": outside range {1:30}";
-      logwrite( function, message.str() );
-      return ERROR;
-    }
-    if ( (channel > 0) && (channel < 25) ) {
-      biasconfig << "LC_V" << channel;
-    }
-    if ( (channel > 24) && (channel < 31) ) {
-      channel -= 24;
-      biasconfig << "HC_V" << channel;
-    }
-
-    if ( (voltage < vmin) || (voltage > vmax) ) {
-      message.str(""); message << "bias voltage " << voltage << ": outside range {" << vmin << ":" << vmax << "}";
-      logwrite( function, message.str() );
-      return ERROR;
-    }
-
-    // Locate this line in the configuration so that it can be written to the Archon
-    //
-    std::string key   = biasconfig.str();
-    std::string value = std::to_string(voltage);
-    bool changed      = false;
-    long error;
-
-    // If no voltage suppled (readonly) then just read the configuration and exit
-    //
-    if (readonly) {
-      message.str("");
-      error = this->get_configmap_value(key, voltage);
-      if (error != NO_ERROR) {
-        message << "reading bias " << key;
-
-      } else {
-        retstring = std::to_string(voltage);
-        message << "read bias " << key << "=" << voltage;
-      }
-      logwrite( function, message.str() );
-      return error;
-    }
-
-    // Write the config line to update the bias voltage
-    //
-    error = this->controller->write_config_key(key.c_str(), value.c_str(), changed);
-
-    // Now send the APPLYMODx command
-    //
-    std::stringstream applystr;
-    applystr << "APPLYMOD"
-             << std::setfill('0')
-             << std::setw(2)
-             << std::hex
-             << (module-1);
-
-    if (error == NO_ERROR) error = this->controller->send_cmd(applystr.str());
-
-    if (error != NO_ERROR) {
-      message << "writing bias configuration: " << key << "=" << value;
-
-    } else if (!changed) {
-      message << "bias configuration: " << key << "=" << value <<" unchanged";
-
-    } else {
-      message << "updated bias configuration: " << key << "=" << value;
-    }
-
-    logwrite(function, message.str());
-
+    logwrite(function, retstring);
     return error;
   }
   /***** Camera::ArchonInterface::bias ****************************************/
@@ -296,160 +178,37 @@ namespace Camera {
 
   /***** Camera::ArchonInterface::connect_controller **************************/
   /**
-   * @brief
+   * @brief      connect to Archon controller
    * @param[in]  args
    * @param[out] retstring
-   * @return     ERROR | NO_ERROR
+   * @return     ERROR | NO_ERROR | HELP
    *
    */
   long ArchonInterface::connect_controller( const std::string args, std::string &retstring ) {
     const std::string function("Camera::ArchonInterface::connect_controller");
-    std::stringstream message;
-    long error;
 
-    // nothing to do if already connected
-    if ( controller->archon.isconnected() ) {
-      logwrite(function, "camera connection already open");
-      return NO_ERROR;
+    // Help
+    if (args=="?" || args=="help") {
+      retstring = CAMERAD_OPEN;
+      retstring.append( "\n" );
+      retstring.append( "  open connection to Archon controller\n" );
+      return HELP;
     }
 
-    // initialize camera connection
+    // connect to the controller
     try {
-      if ( controller->archon.Connect() < 0 ) throw std::runtime_error("could not connect");
+      this->controller->connect();
     }
     catch (const std::exception &e) {
-      logwrite(function, "ERROR "+std::string(e.what()));
-      retstring = "could not connect";
+      logwrite(function, "ERROR: "+std::string(e.what()));
       return ERROR;
     }
 
-    message.str("");
-    message << "socket connection to host " << controller->archon.gethost()
-            << " port " << controller->archon.getport()
-            << " established on fd " << controller->archon.getfd();
-    logwrite(function, message.str());
+    logwrite(function, "connected");
 
-    // get the Archon system information for installed modules
-    std::string reply;
-    error = controller->send_cmd( SYSTEM, reply );    // first the whole reply in one string
-
-    std::vector<std::string> lines, tokens;
-    Tokenize( reply, lines, " " );                    // then each line in a separate token "lines"
-
-    for ( const auto& line : lines ) {
-      Tokenize( line, tokens, "_=" );                 // finally break each line into tokens to get module, type and version
-      if ( tokens.size() != 3 ) continue;             // need 3 tokens
-
-      std::string version;
-      int module=0;
-      int type=0;
-
-      // get the module number
-      //
-      if ( tokens[0].compare( 0, 9, "BACKPLANE" ) == 0 ) {
-        if ( tokens[1] == "VERSION" ) this->controller->backplaneversion = tokens[2];
-        continue;
-      }
-
-      // get the module and type of each module from MODn_TYPE
-      //
-      if ( ( tokens[0].compare( 0, 3, "MOD" ) == 0 ) && ( tokens[1] == "TYPE" ) ) {
-        try {
-          module = std::stoi( tokens[0].substr(3) );
-          type   = std::stoi( tokens[2] );
-
-        } catch (std::invalid_argument &) {
-          message.str(""); message << "unable to convert module or type from " << tokens[0] << "=" << tokens[1] << " to integer";
-          logwrite( function, message.str() );
-          return ERROR;
-
-        } catch (std::out_of_range &) {
-          message.str(""); message << "module " << tokens[0].substr(3) << " or type " << tokens[1] << " out of range";
-          logwrite( function, message.str() );
-          return ERROR;
-        }
-
-      } else continue;
-
-      // get the module version
-      //
-      if ( tokens[1] == "VERSION" ) version = tokens[2]; else version = "";
-
-      // now store it permanently
-      //
-      if ( (module > 0) && (module <= NMODS) ) {
-        try {
-          this->controller->modtype.at(module-1)    = type;      // store the type in a vector indexed by module
-          this->controller->modversion.at(module-1) = version;   // store the type in a vector indexed by module
-        }
-        catch (const std::exception &e) {
-          message.str(""); message << "requested module " << module << " out of range {1:" << NMODS << "}";
-          logwrite( function, message.str() );
-          return ERROR;
-        }
-      }
-      else {                                          // else should never happen
-        message.str(""); message << "module " << module << " outside range {1:" << NMODS << "}";
-        logwrite( function, message.str() );
-        return ERROR;
-      }
-
-      // Use the module type to resize the gain and offset vectors,
-      // but always use the largest possible value allowed.
-      //
-      int adchans=0;
-      if ( type ==  2 ) adchans = ( adchans < MAXADCCHANS ? MAXADCCHANS : adchans );  // ADC module (type=2) found
-      if ( type == 17 ) adchans = ( adchans < MAXADMCHANS ? MAXADMCHANS : adchans );  // ADM module (type=17) found
-      controller->gain.resize( adchans );
-      controller->offset.resize( adchans );
-
-      // Check that the AD modules are installed in the correct slot
-      //
-      if ( ( type == 2 || type == 17 ) && ( module < 5 || module > 8 ) ) {
-        message.str(""); message << "AD module (type=" << type << ") cannot be in slot " << module << ". Use slots 5-8";
-        logwrite( function, message.str() );
-        return ERROR;
-      }
-    } // end for ( auto line : lines )
-
-    // empty the Archon log
-    //
-    error = this->controller->fetchlog();
-
-    return error;
+    return NO_ERROR;
   }
   /***** Camera::ArchonInterface::connect_controller **************************/
-
-
-  /***** Camera::ArchonInterface::get_configmap_value *************************/
-  /**
-   * @brief      get the VALUE from configmap for a givenn KEY and assign to a variable
-   * @param[in]  key_in is the KEY
-   * @param[out] value_out reference to variable to contain the VALUE
-   * @return     ERROR | NO_ERROR
-   *
-   * This is a template class function so the &value_out reference can be any type.
-   * If the key_in KEY is not found then an error message is logged and ERROR is
-   * returned, otherwise the VALUE associated with key_in is assigned to &value_out, 
-   * and NO_ERROR is returned.
-   *
-   */
-  template <class T>
-  long ArchonInterface::get_configmap_value(std::string key_in, T& value_out) {
-    const std::string function("Camera::ArchonInterface::get_configmap_value");
-    std::stringstream message;
-
-    if ( this->controller->configmap.find(key_in) != this->controller->configmap.end() ) {
-      std::istringstream( this->controller->configmap[key_in].value  ) >> value_out;
-      return NO_ERROR;
-    }
-    else {
-      message.str(""); message << "ERROR requested key: " << key_in << " not found in configuration";
-      logwrite( function, message.str() );
-      return ERROR;
-    }
-  }
-  /***** Camera::ArchonInterface::get_configmap_value *************************/
 
 
   /***** Camera::ArchonInterface::disconnect_controller ***********************/

--- a/camerad/archon_interface.cpp
+++ b/camerad/archon_interface.cpp
@@ -61,6 +61,19 @@ namespace Camera {
   /***** Camera::ArchonInterface::controller_cmd ******************************/
 
 
+  /***** Camera::ArchonInterface::configure_interface *************************/
+  /**
+   * @brief      extract+apply interface-specific parameters from config file
+   * @throws     std::runtime_error
+   *
+   */
+  void ArchonInterface::configure_interface() {
+    const std::string function("Camera::ArchonInterface::configure_interface");
+    logwrite(function, "");
+  }
+  /***** Camera::ArchonInterface::configure_interface *************************/
+
+
   /***** Camera::ArchonInterface::abort ***************************************/
   /**
    * @brief

--- a/camerad/archon_interface.cpp
+++ b/camerad/archon_interface.cpp
@@ -165,16 +165,17 @@ namespace Camera {
       float volts;
       size_t ntok = tokens.size();
       bool should_write=false;
+
+      if (ntok != 2 && ntok != 3) {
+        throw std::runtime_error("expected <mod> <chan> [ <volts> ]");
+      }
+
+      mod  = std::stoi(tokens.at(0));
+      chan = std::stoi(tokens.at(1));
+
       if (ntok==3) {
         volts = std::stof(tokens.at(2));
         should_write = true;
-      }
-      if (ntok==2 || ntok==3) {
-        mod  = std::stoi(tokens.at(0));
-        chan = std::stoi(tokens.at(1));
-      }
-      if (ntok != 2 && ntok != 3) {
-        throw std::runtime_error("expected <mod> <chan> [ <volts> ]");
       }
 
       this->controller->bias(mod, chan, volts, should_write);
@@ -690,12 +691,21 @@ namespace Camera {
   /***** Camera::ArchonInterface::allocate_framebuf ***************************/
 
 
+  /***** Camera::ArchonInterface::read_frame **********************************/
+  /**
+   *
+   */
   long ArchonInterface::read_frame() {
     controller->read_frame(Camera::ArchonController::FRAME_IMAGE);
     return NO_ERROR;
   }
+  /***** Camera::ArchonInterface::read_frame **********************************/
 
 
+  /***** Camera::ArchonInterface::do_expose ***********************************/
+  /**
+   *
+   */
   long ArchonInterface::do_expose(int nexp) {
     const std::string function("Camera::ArchonInterface::do_expose");
     long error=NO_ERROR;
@@ -721,17 +731,28 @@ namespace Camera {
 
     return NO_ERROR;
   }
+  /***** Camera::ArchonInterface::do_expose ***********************************/
 
 
+  /***** Camera::ArchonInterface::image_acquisition_thread ********************/
+  /**
+   *
+   */
   void ArchonInterface::image_acquisition_thread() {
     const std::string function("Camera::ArchonInterface::image_acquisition_thread");
     logwrite(function, "here");
   }
+  /***** Camera::ArchonInterface::image_acquisition_thread ********************/
 
 
+  /***** Camera::ArchonInterface::image_processing_thread *********************/
+  /**
+   *
+   */
   void ArchonInterface::image_processing_thread() {
     const std::string function("Camera::ArchonInterface::image_processing_thread");
     logwrite(function, "here");
   }
+  /***** Camera::ArchonInterface::image_processing_thread *********************/
 
 }

--- a/camerad/archon_interface.cpp
+++ b/camerad/archon_interface.cpp
@@ -27,6 +27,40 @@ namespace Camera {
   /***** Camera::ArchonInterface::ArchonInterface *****************************/
 
 
+  /***** Camera::ArchonInterface::controller_cmd ******************************/
+  /**
+   * @brief      dispatcher for Archon-specific commands
+   * @details    This allows dispatching Archon controller specific commands by
+   *             receiving the commands and args and calling the appropriate
+   *             controller-specific function.
+   * @param[in]  cmd        command
+   * @param[in]  args       argument list
+   * @param[out] retstring  return string
+   * @return     ERROR|NO_ERROR|HELP
+   *
+   */
+  long ArchonInterface::controller_cmd(const std::string &cmd,
+                                       const std::string &args,
+                                       std::string &retstring) {
+    if ( cmd == CAMERAD_LOADTIMING ) {
+      return this->load_timing(args, retstring);
+    }
+    else
+    if ( cmd == CAMERAD_READACF ) {
+      return this->read_acf(args);
+    }
+    else
+    if ( cmd == CAMERAD_MODE ) {
+      return this->set_camera_mode(args, retstring);
+    }
+    else {
+      retstring="unrecognized command";
+      return ERROR;
+    }
+  }
+  /***** Camera::ArchonInterface::controller_cmd ******************************/
+
+
   /***** Camera::ArchonInterface::abort ***************************************/
   /**
    * @brief

--- a/camerad/archon_interface.h
+++ b/camerad/archon_interface.h
@@ -12,8 +12,6 @@
 #include "archon_exposure_modes.h"
 #include "camera_information.h"
 
-constexpr int MAXADCCHANS =   16;              //!< max number of ADC channels per controller (4 mod * 4 ch/mod)
-constexpr int MAXADMCHANS =   72;              //!< max number of ADM channels per controller (4 mod * 18 ch/mod)
 constexpr int BLOCK_LEN   = 1024;              //!< Archon block size
 constexpr int REPLY_LEN   =  100 * BLOCK_LEN;  //!< Reply buffer size (over-estimate)
 
@@ -126,7 +124,6 @@ namespace Camera {
       // found in the base class.
       //
       long connect_controller(const std::string& devices_in);
-      template <class T> long get_configmap_value(std::string key_in, T& value_out);
       long load_timing(const std::string &filename);
 
   };

--- a/camerad/archon_interface.h
+++ b/camerad/archon_interface.h
@@ -72,6 +72,7 @@ namespace Camera {
       // and have their own controller-specific implementations which are
       // implemented in archon_interface.cpp.
       //
+      void configure_interface() override;
       long abort( const std::string args, std::string &retstring ) override;
       long autodir( const std::string args, std::string &retstring ) override;
       long basename( const std::string args, std::string &retstring ) override;

--- a/camerad/archon_interface.h
+++ b/camerad/archon_interface.h
@@ -91,6 +91,12 @@ namespace Camera {
       void image_acquisition_thread() override;
       void image_processing_thread() override;
 
+      // Archon controller command dispatcher
+      //
+      long controller_cmd(const std::string &cmd,
+                          const std::string &args,
+                          std::string &retstring) override;
+
       // These functions are specific to the Archon Interface and are not
       // found in the base class.
       //

--- a/camerad/archon_interface_factory.cpp
+++ b/camerad/archon_interface_factory.cpp
@@ -1,0 +1,21 @@
+/**
+ * @file    archon_interface_factory.cpp
+ * @brief   Archon Interface Factory
+ * @author  David Hale <dhale@astro.caltech.edu>
+ *
+ */
+#include "archon_interface.h"
+#include "camera_interface.h"
+
+namespace Camera {
+  /***** Camera::Interface::create ********************************************/
+  /**
+   * @brief      factory function to create pointer to ArchonInterface
+   * @return     unique_ptr<ArchonInterface>
+   *
+   */
+  std::unique_ptr<Interface> Interface::create() {
+    return std::make_unique<ArchonInterface>();
+  }
+  /***** Camera::Interface::create ********************************************/
+}

--- a/camerad/astrocam_interface_factory.cpp
+++ b/camerad/astrocam_interface_factory.cpp
@@ -1,0 +1,21 @@
+/**
+ * @file    astrocam_interface_factory.cpp
+ * @brief   AstroCam Interface Factory
+ * @author  David Hale <dhale@astro.caltech.edu>
+ *
+ */
+#include "astrocam_interface.h"
+#include "camera_interface.h"
+
+namespace Camera {
+  /***** Camera::Interface::create ********************************************/
+  /**
+   * @brief      factory function to create pointer to AstroCamInterface
+   * @return     unique_ptr<AstroCamInterface>
+   *
+   */
+  std::unique_ptr<Interface> Interface::create() {
+    return std::make_unique<AstroCamInterface>();
+  }
+  /***** Camera::Interface::create ********************************************/
+}

--- a/camerad/camera_interface.h
+++ b/camerad/camera_interface.h
@@ -56,6 +56,8 @@ namespace Camera {
       // These virtual functions have interface-specific implementations
       // and must be implemented by derived classes, implemented in xxxx_interface.cpp
       //
+      virtual void configure_interface() = 0;
+      virtual void configure_instrument() { }
       virtual long abort( std::string args, std::string &retstring ) = 0;
       virtual long autodir( std::string args, std::string &retstring ) = 0;
       virtual long basename( std::string args, std::string &retstring ) = 0;

--- a/camerad/camera_interface.h
+++ b/camerad/camera_interface.h
@@ -39,6 +39,11 @@ namespace Camera {
     public:
       virtual ~Interface() = default;
 
+      // Every interface will have this factory function to create a pointer
+      // to the appropriate derived interface class.
+      //
+      static std::unique_ptr<Interface> create();
+
       Config configfile;
 
       // These functions are shared by all interfaces with common implementations,
@@ -71,6 +76,19 @@ namespace Camera {
       virtual void image_acquisition_thread() = 0;
       virtual void image_processing_thread() = 0;
 
+      virtual long instrument_cmd(const std::string &cmd,
+                                  const std::string &args,
+                                  std::string &retstring) {
+	retstring="not_supported";
+	return ERROR;
+      }
+
+      virtual long controller_cmd(const std::string &cmd,
+                                  const std::string &args,
+                                  std::string &retstring) {
+	retstring="not_supported";
+	return ERROR;
+      }
   };
 
 }

--- a/camerad/camera_server.cpp
+++ b/camerad/camera_server.cpp
@@ -43,7 +43,8 @@ namespace Camera {
    *
    */
   void Server::configure_server() {
-    std::stringstream errstr;
+    const std::string function("Camera::Server::configure_server");
+    logwrite(function, "");
 
     if (interface->configfile.n_rows < 1) throw std::runtime_error("empty configuration");
 
@@ -56,9 +57,10 @@ namespace Camera {
           this->blkport = std::stoi( interface->configfile.arg[row] );
         }
         catch (const std::exception &e) {
-          errstr << "parsing " << interface->configfile.param[row]
-                               << "=" << interface->configfile.arg[row] << ": " << e.what();
-          throw std::runtime_error(errstr.str());
+          std::ostringstream oss;
+          oss << "parsing " << interface->configfile.param[row]
+                            << "=" << interface->configfile.arg[row] << ": " << e.what();
+          throw std::runtime_error(oss.str());
         }
       }
     }

--- a/camerad/camera_server.cpp
+++ b/camerad/camera_server.cpp
@@ -7,22 +7,7 @@
 
 #include "camera_server.h"
 
-// The CONTROLLER_xxxx is defined by the CMakeLists file 
-// and selects which Interface implementation to use.
-//
-#ifdef CONTROLLER_ARCHON
-  #include "archon_interface.h"
-  using ControllerType = Camera::ArchonInterface;
-#elif CONTROLLER_ASTROCAM
-  #include "astrocam_interface.h"
-  using ControllerType = Camera::AstroCamInterface;
-#else
-  #error "ERROR controller not defined"
-#endif
-
-
 namespace Camera {
-
 
   /***** Camera::Server::Server ***********************************************/
   /**
@@ -30,13 +15,12 @@ namespace Camera {
    *
    */
   Server::Server() :
-    interface(nullptr),
     blkport(-1),
     id_pool(N_THREADS),
     cmd_num(0)
   {
-    interface = new ControllerType();   // instantiate specific controller implementation
-    interface->set_server(this);        // pointer back to this Server instance
+    interface=Camera::Interface::create();  // factory funcion creates the appropriate interface type
+    interface->set_server(this);            // pointer back to this Server instance
   }
   /***** Camera::Server::Server ***********************************************/
 
@@ -47,7 +31,6 @@ namespace Camera {
    *
    */
   Server::~Server() {
-    delete interface;
   }
   /***** Camera::Server::~Server **********************************************/
 
@@ -278,28 +261,32 @@ namespace Camera {
       if ( cmd == CAMERAD_TEST ) {
         ret = interface->test(args, retstring);
       }
-#ifdef CONTROLLER_ARCHON
-      // These are Archon-controller-specific functions, so the interface
-      // is cast appropriately.
+      /**
+       * instrument-specific commands
+       */
+      else
+      if ( cmd == "hispec_expose" ) {
+        ret = interface->instrument_cmd(cmd, args, retstring);
+      }
+      /**
+       * controller-specific commands
+       */
       else
       if ( cmd == CAMERAD_LOADTIMING ) {
-        dynamic_cast<ArchonInterface*>(interface)->load_timing(args, retstring);
+        ret = interface->controller_cmd(cmd, args, retstring);
       }
       else
       if ( cmd == CAMERAD_READACF ) {
-        dynamic_cast<ArchonInterface*>(interface)->read_acf(args);
+        ret = interface->controller_cmd(cmd, args, retstring);
       }
       else
       if ( cmd == CAMERAD_MODE ) {
-        dynamic_cast<ArchonInterface*>(interface)->set_camera_mode(args, retstring);
+        ret = interface->controller_cmd(cmd, args, retstring);
       }
-#endif
-#ifdef CONTROLLER_BOB
       else
       if ( cmd == "bob" ) {
-        dynamic_cast<BobInterface*>(interface)->bob_only();
+        ret = interface->controller_cmd(cmd, args, retstring);
       }
-#endif
 
       // unknown commands generate an error
       //

--- a/camerad/camera_server.h
+++ b/camerad/camera_server.h
@@ -29,7 +29,7 @@ namespace Camera {
       Server();
       ~Server();
 
-      Interface* interface;
+      std::unique_ptr<Interface> interface;
 
       int blkport;
 

--- a/camerad/camerad.cpp
+++ b/camerad/camerad.cpp
@@ -39,7 +39,8 @@ int main( int argc, char** argv ) {
     camerad.interface->configfile.read_config();
     camerad.configure_server();
     camerad.interface->configure_controller();
-//  camerad.interface->configure_interface();
+    camerad.interface->configure_interface();
+    camerad.interface->configure_instrument();
   }
   catch (const std::exception &e) {
     logwrite(function, "ERROR configuring system: "+std::string(e.what()));


### PR DESCRIPTION
This introduces instrument-specific modules that are selected at compile time using:

`cmake -DCONTROLLER=<controller> [ -DINSTRUMENT=<instrument> ] ..`

where `<controller>` is a valid controller name of `{ archon astrocam }`
and `<instrument>` is an optional instrument name which is not specified by name in the `CMakeLists.txt` file, but must have a matching subdirectory under `Instruments/`. I have added `Instruments/` and its subdirectory to this repo but in the future I expect to make these submodules so that the main repo can be distributed without having to distribute instrument-specific code to projects that do not pertain to those instruments.

E.G.
`cmake -DCONTROLLER=archon -DINSTRUMENT=hispec ..`
for building for the HISPEC instrument, or
`cmake -DCONTROLLER=archon ..`
for building for a generic Archon controller without instrument-specific needs.

This commit also removes the previous need for #ifdefs in camera_server, which is supposed to be generic and not have to know about specific controllers or instruments. This is done using a factory function which creates a smart pointer to the appropriate derived Interface class, and gets included using the command line arguments to cmake.

controller-specific and instrument-specific commands are then invoked using a dispatcher.

Currently, camera_server still knows about all commands but @prkrtg will change this at some point.

This PR is branched from DH/archon-controller (PR #84).

This has been compiled and tested.