### PR TITLE
Raw retrieval mode

### DIFF
--- a/camerad/archon_controller.cpp
+++ b/camerad/archon_controller.cpp
@@ -579,13 +579,17 @@ namespace Camera {
             else
             if (std::strncmp(suffix, "HEIGHT", 6)==0) this->frameinfo.bufheight[bufnum] = std::atoi(value_start);
             break;
-          case 8:  // BUFnCOMPLETE
+          case 8:  // BUFnCOMPLETE, RAWLINES
             if (std::strncmp(suffix, "COMPLETE", 8)==0) this->frameinfo.bufcomplete[bufnum] = std::atoi(value_start);
+            else
+            if (std::strncmp(suffix, "RAWLINES", 8)==0) this->frameinfo.bufrawlines[bufnum] = std::atoi(value_start);
             break;
-          case 9:  // BUFnTIMESTAMP, RAWOFFSET
+          case 9:  // BUFnTIMESTAMP, RAWOFFSET, RAWBLOCKS
             if (std::strncmp(suffix, "TIMESTAMP", 9)==0) this->frameinfo.buftimestamp[bufnum] = std::strtoull(value_start, nullptr, 16);
             else
             if (std::strncmp(suffix, "RAWOFFSET", 9)==0) this->frameinfo.bufrawoffset[bufnum] = std::strtoul(value_start, nullptr, 10);
+            else
+            if (std::strncmp(suffix, "RAWBLOCKS", 9)==0) this->frameinfo.bufrawblocks[bufnum] = std::atoi(value_start);
             break;
           case 11: // BUFnRETIMESTAMP, FETIMESTAMP
             if (std::strncmp(suffix, "RETIMESTAMP", 11)==0) this->frameinfo.bufretimestamp[bufnum] = std::strtoull(value_start, nullptr, 16);
@@ -2051,17 +2055,44 @@ namespace Camera {
   /***** Camera::ArchonController::is_raw_config_key *************************/
 
 
+  /***** Camera::ArchonController::raw_geometry ****************************/
+  /**
+   * @brief      resolve RAW capture geometry for the newest buffer
+   * @details    Prefers the controller-reported BUFnRAWBLOCKS/BUFnRAWLINES,
+   *             which already account for the per-line rounding to whole
+   *             1024-byte blocks. Falls back to the config keys when the
+   *             controller has not reported them (e.g. emulator). The line
+   *             range is inclusive: RAWSTARTLINE=0,RAWENDLINE=1 is two lines.
+   */
+  ArchonController::raw_geometry_t ArchonController::raw_geometry() const {
+    const auto index = this->frameinfo.index.load();
+    raw_geometry_t geom;
+    geom.samples         = static_cast<uint32_t>(this->rawinfo.samples);
+    geom.blocks_per_line = static_cast<uint32_t>(this->frameinfo.bufrawblocks[index]);
+    geom.lines           = static_cast<uint32_t>(this->frameinfo.bufrawlines[index]);
+
+    if (geom.blocks_per_line == 0 || geom.lines == 0) {
+      geom.blocks_per_line =
+        (static_cast<size_t>(geom.samples) * sizeof(uint16_t) + BLOCK_LEN - 1) / BLOCK_LEN;
+      const int span = this->rawinfo.endline - this->rawinfo.startline + 1;
+      geom.lines = span > 0 ? static_cast<uint32_t>(span) : 0u;
+    }
+    return geom;
+  }
+  /***** Camera::ArchonController::raw_geometry ****************************/
+
+
   /***** Camera::ArchonController::raw_frame_bytes **************************/
   /**
-   * @brief      size-aware byte count for one RAW capture
-   * @details    RAW samples are always 16-bit. Count = rawlines x RAWSAMPLES,
-   *             rawlines = RAWENDLINE - RAWSTARTLINE. RAWSTARTPIXEL only sets
-   *             the reshape origin, so it does not change the sample count.
+   * @brief      padded, size-aware byte count for one RAW fetch
+   * @details    Each line occupies whole 1024-byte blocks, so the fetch reads
+   *             blocks_per_line x lines blocks. RAW samples are always 16-bit;
+   *             RAWSTARTPIXEL only sets where sampling begins in a line and so
+   *             does not change the count.
    */
   uint32_t ArchonController::raw_frame_bytes() const {
-    const int lines = this->rawinfo.endline - this->rawinfo.startline;
-    const uint32_t rawlines = lines > 0 ? static_cast<uint32_t>(lines) : 1u;
-    return rawlines * static_cast<uint32_t>(this->rawinfo.samples) * sizeof(uint16_t);
+    const raw_geometry_t geom = this->raw_geometry();
+    return geom.blocks_per_line * geom.lines * BLOCK_LEN;
   }
   /***** Camera::ArchonController::raw_frame_bytes **************************/
 
@@ -2116,7 +2147,7 @@ namespace Camera {
       }
     }
 
-    if (changed && this->send_cmd(APPLYALL) != NO_ERROR) {
+    if (changed && this->send_cmd(APPLYCDS) != NO_ERROR) {
       logwrite(function, "ERROR applying RAW configuration");
       retstring = "failed to apply";
       return ERROR;
@@ -2147,16 +2178,16 @@ namespace Camera {
 
     this->get_frame_status();
 
-    const uint32_t bytes = this->raw_frame_bytes();
-    if (bytes == 0) {
-      logwrite(function, "ERROR RAW geometry yields zero bytes; check RAW config");
+    const raw_geometry_t geom = this->raw_geometry();
+    if (geom.samples == 0 || geom.lines == 0) {
+      logwrite(function, "ERROR RAW geometry is empty; check RAW config");
       retstring = "invalid RAW geometry";
       return ERROR;
     }
 
-    const size_t nblocks = (bytes + BLOCK_LEN - 1) / BLOCK_LEN;
-    std::shared_ptr<char[]> buffer(new char[nblocks * BLOCK_LEN]);
-    char* bufptr = buffer.get();
+    const size_t fetch_bytes = static_cast<size_t>(geom.blocks_per_line) * geom.lines * BLOCK_LEN;
+    std::shared_ptr<char[]> raw_buffer(new char[fetch_bytes]);
+    char* bufptr = raw_buffer.get();
 
     if (this->read_frame(FRAME_RAW, bufptr) != NO_ERROR) {
       logwrite(function, "ERROR reading RAW frame");
@@ -2164,20 +2195,31 @@ namespace Camera {
       return ERROR;
     }
 
-    const int lines = this->rawinfo.endline - this->rawinfo.startline;
-    const uint32_t rawlines = lines > 0 ? static_cast<uint32_t>(lines) : 1u;
+    // The Archon pads each raw line out to whole 1024-byte blocks, so copy only
+    // the valid RAWSAMPLES from each line into a contiguous lines x samples array
+    const size_t line_stride = static_cast<size_t>(geom.blocks_per_line) * BLOCK_LEN;
+    const size_t payload_samples = static_cast<size_t>(geom.lines) * geom.samples;
+    std::vector<uint16_t> samples(payload_samples);
+    for (uint32_t line = 0; line < geom.lines; ++line) {
+      std::memcpy(samples.data() + static_cast<size_t>(line) * geom.samples,
+                  raw_buffer.get() + line * line_stride,
+                  static_cast<size_t>(geom.samples) * sizeof(uint16_t));
+    }
+
     const auto index = this->frameinfo.index.load();
+    const size_t payload_bytes = payload_samples * sizeof(uint16_t);
 
     Camera::FrameMetadata meta;
     meta.frame_number    = this->frameinfo.bufframen[index];
     meta.timestamp       = this->frameinfo.buftimestamp[index];
-    meta.width           = this->rawinfo.samples;
-    meta.height          = rawlines;
+    meta.width           = geom.samples;
+    meta.height          = geom.lines;
     meta.bytes_per_pixel = sizeof(uint16_t);
-    this->interface->dispatch_frame(buffer.get(), bytes, meta);
+    this->interface->dispatch_frame(reinterpret_cast<const char*>(samples.data()),
+                                    payload_bytes, meta);
 
     std::ostringstream oss;
-    oss << "samples=" << this->rawinfo.samples << " lines=" << rawlines << " bytes=" << bytes;
+    oss << "samples=" << geom.samples << " lines=" << geom.lines << " bytes=" << payload_bytes;
     retstring = oss.str();
     logwrite(function, retstring);
     return NO_ERROR;

--- a/camerad/archon_controller.cpp
+++ b/camerad/archon_controller.cpp
@@ -582,8 +582,10 @@ namespace Camera {
           case 8:  // BUFnCOMPLETE
             if (std::strncmp(suffix, "COMPLETE", 8)==0) this->frameinfo.bufcomplete[bufnum] = std::atoi(value_start);
             break;
-          case 9:  // BUFnTIMESTAMP
+          case 9:  // BUFnTIMESTAMP, RAWOFFSET
             if (std::strncmp(suffix, "TIMESTAMP", 9)==0) this->frameinfo.buftimestamp[bufnum] = std::strtoull(value_start, nullptr, 16);
+            else
+            if (std::strncmp(suffix, "RAWOFFSET", 9)==0) this->frameinfo.bufrawoffset[bufnum] = std::strtoul(value_start, nullptr, 10);
             break;
           case 11: // BUFnRETIMESTAMP, FETIMESTAMP
             if (std::strncmp(suffix, "RETIMESTAMP", 11)==0) this->frameinfo.bufretimestamp[bufnum] = std::strtoull(value_start, nullptr, 16);
@@ -1608,8 +1610,10 @@ namespace Camera {
       this->get_configmap_value("FRAMEMODE", mode->geometry.framemode);
       this->get_configmap_value("RAWENABLE", mode->rawenable);
       this->get_configmap_value("RAWSEL", this->rawinfo.adchan);
-      this->get_configmap_value("RAWSAMPLES", this->rawinfo.rawsamples);
-      this->get_configmap_value("RAWENDLINE", this->rawinfo.rawlines);
+      this->get_configmap_value("RAWSAMPLES", this->rawinfo.samples);
+      this->get_configmap_value("RAWSTARTLINE", this->rawinfo.startline);
+      this->get_configmap_value("RAWENDLINE", this->rawinfo.endline);
+      this->get_configmap_value("RAWSTARTPIXEL", this->rawinfo.startpixel);
 
       // Read geometry from the mode's configmap (not the global one) since each
       // mode section can override LINECOUNT/PIXELCOUNT
@@ -1911,11 +1915,10 @@ namespace Camera {
     //
     switch (this->frametype) {
       case Camera::ArchonController::FRAME_RAW:
-        // Archon buffer base address
+        // RAW data lives at bufbase + rawoffset; block count derives from the
+        // RAW geometry (RAWSAMPLES x rawlines x 2 bytes), never image_memory
         bufaddr   = this->frameinfo.bufbase[index] + this->frameinfo.bufrawoffset[index];
-
-        // Calculate the number of blocks expected. image_memory is bytes per detector
-        bufblocks = (unsigned int) floor( (this->interface->camera_info.image_memory + BLOCK_LEN - 1 ) / BLOCK_LEN );
+        bufblocks = (this->raw_frame_bytes() + BLOCK_LEN - 1) / BLOCK_LEN;
         break;
 
       case Camera::ArchonController::FRAME_IMAGE:
@@ -2032,6 +2035,154 @@ namespace Camera {
 
     return error;
   }
+
+
+  /***** Camera::ArchonController::is_raw_config_key *************************/
+  /**
+   * @brief      return true if key is one of the settable RAW config keywords
+   */
+  bool ArchonController::is_raw_config_key(const std::string &key) {
+    for (const auto* raw_key : {"RAWENABLE", "RAWSEL", "RAWSTARTLINE",
+                                "RAWENDLINE", "RAWSTARTPIXEL", "RAWSAMPLES"}) {
+      if (key == raw_key) return true;
+    }
+    return false;
+  }
+  /***** Camera::ArchonController::is_raw_config_key *************************/
+
+
+  /***** Camera::ArchonController::raw_frame_bytes **************************/
+  /**
+   * @brief      size-aware byte count for one RAW capture
+   * @details    RAW samples are always 16-bit. Count = rawlines x RAWSAMPLES,
+   *             rawlines = RAWENDLINE - RAWSTARTLINE. RAWSTARTPIXEL only sets
+   *             the reshape origin, so it does not change the sample count.
+   */
+  uint32_t ArchonController::raw_frame_bytes() const {
+    const int lines = this->rawinfo.endline - this->rawinfo.startline;
+    const uint32_t rawlines = lines > 0 ? static_cast<uint32_t>(lines) : 1u;
+    return rawlines * static_cast<uint32_t>(this->rawinfo.samples) * sizeof(uint16_t);
+  }
+  /***** Camera::ArchonController::raw_frame_bytes **************************/
+
+
+  /***** Camera::ArchonController::get_raw_config **************************/
+  /**
+   * @brief      report the current RAW configuration keywords
+   * @param[out] retstring  space-delimited KEY=VALUE pairs
+   */
+  long ArchonController::get_raw_config(std::string &retstring) {
+    std::ostringstream oss;
+    for (const auto* key : {"RAWENABLE", "RAWSEL", "RAWSTARTLINE",
+                            "RAWENDLINE", "RAWSTARTPIXEL", "RAWSAMPLES"}) {
+      auto it = this->configmap.find(key);
+      oss << key << "=" << (it != this->configmap.end() ? it->second.value : "?") << " ";
+    }
+    retstring = oss.str();
+    return NO_ERROR;
+  }
+  /***** Camera::ArchonController::get_raw_config **************************/
+
+
+  /***** Camera::ArchonController::set_raw_config **************************/
+  /**
+   * @brief      set one or more RAW config keywords then APPLYALL
+   * @param[in]  args       "KEY VALUE [KEY VALUE ...]"
+   * @param[out] retstring  resulting RAW configuration
+   */
+  long ArchonController::set_raw_config(const std::string &args, std::string &retstring) {
+    const std::string function("Camera::ArchonController::set_raw_config");
+
+    std::vector<std::string> tokens;
+    Tokenize(args, tokens, " ");
+    if (tokens.empty() || tokens.size() % 2 != 0) {
+      logwrite(function, "ERROR expected KEY VALUE pairs");
+      retstring = "expected KEY VALUE pairs";
+      return ERROR;
+    }
+
+    bool changed = false;
+    for (size_t i = 0; i < tokens.size(); i += 2) {
+      std::string key = tokens[i];
+      std::transform(key.begin(), key.end(), key.begin(), ::toupper);
+      if (!is_raw_config_key(key)) {
+        logwrite(function, "ERROR unknown RAW key: "+key);
+        retstring = "unknown RAW key: "+key;
+        return ERROR;
+      }
+      if (this->write_config_key(key.c_str(), tokens[i+1].c_str(), changed) != NO_ERROR) {
+        retstring = "failed writing "+key;
+        return ERROR;
+      }
+    }
+
+    if (changed && this->send_cmd(APPLYALL) != NO_ERROR) {
+      logwrite(function, "ERROR applying RAW configuration");
+      retstring = "failed to apply";
+      return ERROR;
+    }
+
+    // refresh cached geometry from the now-updated configmap
+    this->get_configmap_value("RAWSEL", this->rawinfo.adchan);
+    this->get_configmap_value("RAWSAMPLES", this->rawinfo.samples);
+    this->get_configmap_value("RAWSTARTLINE", this->rawinfo.startline);
+    this->get_configmap_value("RAWENDLINE", this->rawinfo.endline);
+    this->get_configmap_value("RAWSTARTPIXEL", this->rawinfo.startpixel);
+
+    return this->get_raw_config(retstring);
+  }
+  /***** Camera::ArchonController::set_raw_config **************************/
+
+
+  /***** Camera::ArchonController::read_raw *******************************/
+  /**
+   * @brief      retrieve RAW (pre-CDS) data from the newest frame buffer
+   * @details    Reads the size-aware RAW region as 16-bit unsigned samples and
+   *             dispatches it in-band as a (RAWSAMPLES x rawlines) frame,
+   *             independent of the post-CDS pixel mode.
+   * @param[out] retstring  "samples=<w> lines=<h> bytes=<n>"
+   */
+  long ArchonController::read_raw(std::string &retstring) {
+    const std::string function("Camera::ArchonController::read_raw");
+
+    this->get_frame_status();
+
+    const uint32_t bytes = this->raw_frame_bytes();
+    if (bytes == 0) {
+      logwrite(function, "ERROR RAW geometry yields zero bytes; check RAW config");
+      retstring = "invalid RAW geometry";
+      return ERROR;
+    }
+
+    const size_t nblocks = (bytes + BLOCK_LEN - 1) / BLOCK_LEN;
+    std::shared_ptr<char[]> buffer(new char[nblocks * BLOCK_LEN]);
+    char* bufptr = buffer.get();
+
+    if (this->read_frame(FRAME_RAW, bufptr) != NO_ERROR) {
+      logwrite(function, "ERROR reading RAW frame");
+      retstring = "read failed";
+      return ERROR;
+    }
+
+    const int lines = this->rawinfo.endline - this->rawinfo.startline;
+    const uint32_t rawlines = lines > 0 ? static_cast<uint32_t>(lines) : 1u;
+    const auto index = this->frameinfo.index.load();
+
+    Camera::FrameMetadata meta;
+    meta.frame_number    = this->frameinfo.bufframen[index];
+    meta.timestamp       = this->frameinfo.buftimestamp[index];
+    meta.width           = this->rawinfo.samples;
+    meta.height          = rawlines;
+    meta.bytes_per_pixel = sizeof(uint16_t);
+    this->interface->dispatch_frame(buffer.get(), bytes, meta);
+
+    std::ostringstream oss;
+    oss << "samples=" << this->rawinfo.samples << " lines=" << rawlines << " bytes=" << bytes;
+    retstring = oss.str();
+    logwrite(function, retstring);
+    return NO_ERROR;
+  }
+  /***** Camera::ArchonController::read_raw *******************************/
 
 
   /***** Camera::ArchonController::wait_for_readout ***************************/

--- a/camerad/archon_controller.h
+++ b/camerad/archon_controller.h
@@ -249,10 +249,13 @@ namespace Camera {
       cfg_map_t configmap;
       param_map_t parammap;
 
+      /** @brief Archon RAW (pre-CDS) capture configuration, mirrors ACF keywords */
       struct rawinfo_t {
-        int adchan;
-        uint16_t rawsamples;
-        uint16_t rawlines;
+        int      adchan{0};      // RAWSEL: AD channel captured
+        uint16_t samples{0};     // RAWSAMPLES: 16-bit samples per line
+        uint16_t startline{0};   // RAWSTARTLINE
+        uint16_t endline{0};     // RAWENDLINE
+        uint16_t startpixel{0};  // RAWSTARTPIXEL
       } rawinfo;
 
       /**
@@ -344,6 +347,13 @@ namespace Camera {
       long read_frame(frametype_t type, char* &imagebufferptr);
       long write_config_key(const char* key, const char* newvalue, bool &changed);
       long write_config_key(const char* key, int newvalue, bool &changed);
+
+      // RAW (pre-CDS) capture: configuration and retrieval
+      static bool is_raw_config_key(const std::string &key);
+      uint32_t raw_frame_bytes() const;   // size-aware byte count for a RAW fetch
+      long set_raw_config(const std::string &args, std::string &retstring);
+      long get_raw_config(std::string &retstring);
+      long read_raw(std::string &retstring);
 
 
       std::map<std::string, modeinfo_t> modemap;

--- a/camerad/archon_controller.h
+++ b/camerad/archon_controller.h
@@ -349,8 +349,16 @@ namespace Camera {
       long write_config_key(const char* key, int newvalue, bool &changed);
 
       // RAW (pre-CDS) capture: configuration and retrieval
+      /** @brief resolved RAW capture geometry for the newest buffer */
+      struct raw_geometry_t {
+        uint32_t samples;          // valid 16-bit samples per line (RAWSAMPLES)
+        uint32_t blocks_per_line;  // 1024-byte blocks per line, padded per Archon
+        uint32_t lines;            // number of raw lines (RAWENDLINE-RAWSTARTLINE+1)
+      };
+
       static bool is_raw_config_key(const std::string &key);
-      uint32_t raw_frame_bytes() const;   // size-aware byte count for a RAW fetch
+      raw_geometry_t raw_geometry() const;
+      uint32_t raw_frame_bytes() const;   // padded, size-aware byte count for a RAW fetch
       long set_raw_config(const std::string &args, std::string &retstring);
       long get_raw_config(std::string &retstring);
       long read_raw(std::string &retstring);

--- a/camerad/archon_interface.cpp
+++ b/camerad/archon_interface.cpp
@@ -68,6 +68,10 @@ namespace Camera {
       return this->set_camera_mode(args, retstring);
     }
     else
+    if ( cmd == CAMERAD_RAW ) {
+      return this->raw(args, retstring);
+    }
+    else
     if ( cmd == "autofetch_mode" ) {
       return this->autofetch_mode(args, retstring);
     }
@@ -942,6 +946,48 @@ namespace Camera {
     return this->controller->set_vcpu_inreg(args);
   }
   /***** Camera::ArchonInterface::set_vcpu_inreg ******************************/
+
+
+  /***** Camera::ArchonInterface::raw ****************************************/
+  /**
+   * @brief      configure and retrieve Archon RAW (pre-CDS) data
+   * @param[in]  args       "config" | "set <KEY> <VAL> [...]" | "read"
+   * @param[out] retstring  RAW configuration or retrieval summary
+   * @return     ERROR | NO_ERROR | HELP
+   *
+   */
+  long ArchonInterface::raw( const std::string args, std::string &retstring ) {
+    const std::string function("Camera::ArchonInterface::raw");
+
+    if (args=="?" || args=="help") {
+      retstring = CAMERAD_RAW;
+      retstring.append( " [ config | set <KEY> <VAL> [...] | read ]\n" );
+      retstring.append( "  config              report the RAW config keywords\n" );
+      retstring.append( "  set <KEY> <VAL> ..  set RAW keyword(s) then apply\n" );
+      retstring.append( "  read                retrieve RAW data in-band as 16-bit samples\n" );
+      retstring.append( "  Keys: RAWENABLE RAWSEL RAWSTARTLINE RAWENDLINE RAWSTARTPIXEL RAWSAMPLES\n" );
+      return HELP;
+    }
+
+    std::size_t sep = args.find_first_of(" ");
+    const std::string subcmd = args.substr(0, sep);
+    const std::string subargs = (sep==std::string::npos) ? "" : args.substr(sep+1);
+
+    if (subcmd.empty() || subcmd=="config") {
+      return this->controller->get_raw_config(retstring);
+    }
+    if (subcmd=="set") {
+      return this->controller->set_raw_config(subargs, retstring);
+    }
+    if (subcmd=="read") {
+      return this->controller->read_raw(retstring);
+    }
+
+    logwrite(function, "ERROR unrecognized subcommand: "+subcmd);
+    retstring = "unrecognized subcommand: "+subcmd;
+    return ERROR;
+  }
+  /***** Camera::ArchonInterface::raw ****************************************/
 
 
   /***** Camera::ArchonInterface::native **************************************/

--- a/camerad/archon_interface.h
+++ b/camerad/archon_interface.h
@@ -43,6 +43,7 @@ namespace Camera {
       long load_firmware( const std::string &args, std::string &retstring ) override;
       long native( const std::string args, std::string &retstring ) override;
       long power( const std::string args, std::string &retstring ) override;
+      long raw( const std::string args, std::string &retstring );
       long test( const std::string args, std::string &retstring ) override;
 
       long do_expose() override;

--- a/camerad/camera_interface.cpp
+++ b/camerad/camera_interface.cpp
@@ -1,4 +1,5 @@
 #include "camera_interface.h"
+#include "frame_output_factory.h"
 
 namespace Camera {
 
@@ -7,6 +8,21 @@ namespace Camera {
   void Interface::set_server(Camera::Server* s) {
     this->server=s;
   }
+
+  /***** Camera::Interface::configure_frame_outputs ***************************/
+  /**
+   * @brief      build the in-band frame output sinks (FITS, shared memory)
+   * @details    dispatch_frame fans every retrieved frame out to these
+   *
+   */
+  void Interface::configure_frame_outputs() {
+    const std::string function("Camera::Interface::configure_frame_outputs");
+    FrameOutputsConfig outcfg;
+    apply_config_overrides(outcfg, this->configfile);
+    this->frame_outputs = make_frame_outputs(outcfg);
+    logwrite(function, "configured "+std::to_string(this->frame_outputs.size())+" frame output(s)");
+  }
+  /***** Camera::Interface::configure_frame_outputs ***************************/
 
   void Interface::func_shared() {
     std::string function("Camera::Interface::func_shared");

--- a/camerad/camera_interface.h
+++ b/camerad/camera_interface.h
@@ -75,6 +75,7 @@ namespace Camera {
       //
       void set_server(Camera::Server* s);
       void func_shared();
+      void configure_frame_outputs();
       void disconnect_controller();
       bool is_exposuremode_set() { return ( this->exposuremode && !this->exposuremode->get_type().empty() ); }
 

--- a/camerad/camera_server.cpp
+++ b/camerad/camera_server.cpp
@@ -321,6 +321,10 @@ namespace Camera {
         ret = interface->controller_cmd(cmd, args, retstring);
       }
       else
+      if ( cmd == CAMERAD_RAW ) {
+        ret = interface->controller_cmd(cmd, args, retstring);
+      }
+      else
       if ( cmd == "bob" ) {
         ret = interface->controller_cmd(cmd, args, retstring);
       }

--- a/camerad/camerad.cpp
+++ b/camerad/camerad.cpp
@@ -48,6 +48,7 @@ int main( int argc, char** argv ) {
     camerad.interface->configure_controller();
     camerad.interface->configure_interface();
     camerad.interface->configure_instrument();
+    camerad.interface->configure_frame_outputs();
   }
   catch (const std::exception &e) {
     logwrite(function, "ERROR configuring system: "+std::string(e.what()));

--- a/common/camerad_commands.h
+++ b/common/camerad_commands.h
@@ -44,6 +44,7 @@ const std::string CAMERAD_OPEN("open");  const int CAMERAD_OPEN_TIMEOUT(10000);
 const std::string CAMERAD_PAUSE("pause");
 const std::string CAMERAD_POWER("power");
 const std::string CAMERAD_PREEXPOSURES("preexposures");
+const std::string CAMERAD_RAW("raw");
 const std::string CAMERAD_READACF("readacf");
 const std::string CAMERAD_READOUT("readout");
 const std::string CAMERAD_RESUME("resume");
@@ -88,6 +89,7 @@ const std::vector<std::string> CAMERAD_SYNTAX = {
                                                   CAMERAD_OPEN+" [ ? | <devlist> ]",
                                                   CAMERAD_PAUSE,
                                                   CAMERAD_PREEXPOSURES,
+                                                  CAMERAD_RAW+" [ ? | config | set <KEY> <VAL> [...] | read ]",
                                                   CAMERAD_READACF+" [ ? | <acffile> ]",
                                                   CAMERAD_READOUT+" [ ? ] | [ <dev#> | <chan> [ <amp> ] ]",
                                                   CAMERAD_RESUME,


### PR DESCRIPTION
# Archon RAW-Mode Retrieval

## What RAW mode is

The Archon continuously samples each CCD output at 16-bit / 100 MHz. Normal image
data is the result of on-chip **CDS** (correlated double sampling) and is useless
for many electrical measurements. RAW mode instead captures the **raw ADC samples
from a single AD channel, before CDS**, an oscilloscope view of the CCD output
waveform. Use it to inspect settling time, reset-level stability, clock
feedthrough, and to choose optimal CDS sample windows (SHP/SHD), or to optimise
read noise and linearity.

RAW is captured **alongside** the normal image during the same exposure, from the
same frame buffer. Because the frame buffer is finite, only a portion of the frame
can be captured this way.

## The `raw` command

| Command | Effect |
|---|---|
| `raw config` | report the current RAW keyword values |
| `raw set <KEY> <VAL> [<KEY> <VAL> ...]` | set RAW keyword(s), then apply (`APPLYCDS`) |
| `raw read` | retrieve RAW from the newest buffer and deliver it in-band |
| `raw ?` | help |

## The six configuration keys

| Key | Meaning |
|---|---|
| `RAWENABLE` | `1` to enable RAW capture, `0` to disable |
| `RAWSEL` | AD channel to capture: `0` = ch1 of the ADC in slot 5 … `15` = ch4 of the ADC in slot 8 |
| `RAWSTARTLINE` | first line to capture (0–65535) |
| `RAWENDLINE` | last line to capture (0–65535) — **inclusive** |
| `RAWSTARTPIXEL` | pixel within each line where sampling begins |
| `RAWSAMPLES` | 16-bit samples to store per line (rounded up to whole 1024-byte blocks) |

`RAWSTARTLINE=0, RAWENDLINE=1` captures **two** lines. `RAWSTARTPIXEL` only sets
*where in the line* sampling starts; it does not change the number of samples.

The ACF must already define these six keys — `raw set` writes existing keys, it
cannot create them.

## Retrieving RAW data

```
raw config                                              # inspect current settings
raw set RAWENABLE 1 RAWSEL 0 RAWSTARTLINE 0 RAWENDLINE 1 RAWSTARTPIXEL 0 RAWSAMPLES 2048
expose                                                  # RAW captured alongside the image
raw read                                                # retrieve it
```

`raw read` returns a summary line, e.g.:

```
samples=2048 lines=2 bytes=8192 DONE
```

and delivers the data **in-band** to whatever frame-output sink is configured
(a FITS file, or a shared-memory object with `SHM_ENABLED=yes`) — no separate
file to go and load.

## The retrieved data

The delivered frame is a `lines × RAWSAMPLES` array of **`uint16`** (always 16-bit,
even when the pixel mode is HDR/32-bit):

- each **row** is one CCD line's raw waveform;
- the **x axis** is sample number (10 ns per sample at 100 MHz);
- the **y axis** is ADC counts (DN).

Plot a row and you have the oscilloscope trace of that line's readout.

```python
from astropy.io import fits
import matplotlib.pyplot as plt
raw = fits.getdata("raw_00000001_1.fits")   # shape (lines, RAWSAMPLES), uint16
plt.plot(raw[0])                            # first line's raw waveform
```

## Watch the size

Bytes ≈ `(RAWENDLINE − RAWSTARTLINE + 1) × RAWSAMPLES × 2`, padded up per line to
whole 1024-byte blocks. RAW fills the frame buffer fast, per the Archon manual,
1000 lines × 1000 samples at a 100 kHz pixel clock is ~2 GB. Start small.

## How it works (reference)

Mirrors the pixel-data path, per the Archon ICD:

1. `FRAME?` reports `BUFnRAWOFFSET`, `BUFnRAWBLOCKS` (blocks per line) and
   `BUFnRAWLINES` for each buffer.
2. camerad locks the buffer (`LOCKn`) and issues `FETCH` from
   **`BUFnBASE + BUFnRAWOFFSET`** (not `BUFnBASE`), sized from the reported raw
   blocks/lines (falling back to the config keys if the controller does not
   report them).
3. The fetched buffer is stripped of its per-line block padding, reshaped to
   `lines × RAWSAMPLES`, and dispatched in-band as 16-bit samples.

## Status / caveats

- Validated end-to-end against the Archon **emulator**: a known ramp fed through
  round-trips byte-for-byte at the correct `lines × RAWSAMPLES` shape.
- The emulator serves RAW at offset 0, so the nonzero-`BUFnRAWOFFSET` path should
  be confirmed on real hardware during first use.
- Retrieving RAW-only (`raw read`) and pixel-only (`expose`) from the same buffer
  works today; a single combined command is a possible future addition.
